### PR TITLE
fix:[meta] update security policy; add IRP

### DIFF
--- a/.github/INCIDENT_RESPONSE_PLAN.md
+++ b/.github/INCIDENT_RESPONSE_PLAN.md
@@ -1,0 +1,117 @@
+# Incident Response Process for **nvm**
+
+## Reporting a Vulnerability
+
+We take the security of **nvm** very seriously. If you believe you’ve found a security vulnerability, please inform us responsibly through coordinated disclosure.
+
+### How to Report
+
+> **Do not** report security vulnerabilities through public GitHub issues, discussions, or social media.
+
+Instead, please use one of these secure channels:
+
+1. **GitHub Security Advisories**
+    Use the **Report a vulnerability** button in the Security tab of the [nvm-sh/nvm repository](https://github.com/nvm-sh/nvm).
+
+2. **Email**
+    Follow the posted [Security Policy](https://github.com/nvm-sh/nvm/security/policy).
+
+### What to Include
+
+**Required Information:**
+- Brief description of the vulnerability type
+- Affected version(s) and components
+- Steps to reproduce the issue
+- Impact assessment (what an attacker could achieve)
+
+**Helpful Additional Details:**
+- Full paths of affected scripts or files
+- Specific commit or branch where the issue exists
+- Required configuration to reproduce
+- Proof-of-concept code (if available)
+- Suggested mitigation or fix
+
+## Our Response Process
+
+**Timeline Commitments:**
+- **Initial acknowledgment**: Within 24 hours
+- **Detailed response**: Within 3 business days
+- **Status updates**: Every 7 days until resolved
+- **Resolution target**: 90 days for most issues
+
+**What We’ll Do:**
+1. Acknowledge your report and assign a tracking ID
+2. Assess the vulnerability and determine severity
+3. Develop and test a fix
+4. Coordinate disclosure timeline with you
+5. Release a security update and publish an advisory and CVE
+6. Credit you in our security advisory (if desired)
+
+## Disclosure Policy
+
+- **Coordinated disclosure**: We’ll work with you on timing
+- **Typical timeline**: 90 days from report to public disclosure
+- **Early disclosure**: If actively exploited
+- **Delayed disclosure**: For complex issues
+
+## Scope
+
+**In Scope:**
+- **nvm** project (all supported versions)
+- Installation and update scripts (`install.sh`, `nvm.sh`)
+- Official documentation and CI/CD integrations
+- Dependencies with direct security implications
+
+**Out of Scope:**
+- Third-party forks or mirrors
+- Platform-specific installs outside core scripts
+- Social engineering or physical attacks
+- Theoretical vulnerabilities without practical exploitation
+
+## Security Measures
+
+**Our Commitments:**
+- Regular vulnerability scanning via GitHub Actions
+- Automated security checks in CI/CD pipelines
+- Secure scripting practices and mandatory code review
+- Prompt patch releases for critical issues
+
+**User Responsibilities:**
+- Keep **nvm** updated
+- Verify script downloads via PGP signatures
+- Follow secure configuration guidelines for shell environments
+
+## Legal Safe Harbor
+
+**We will NOT:**
+- Initiate legal action
+- Contact law enforcement
+- Suspend or terminate your access
+
+**You must:**
+- Only test against your own installations
+- Not access, modify, or delete user data
+- Not degrade service availability
+- Not publicly disclose before coordinated disclosure
+- Act in good faith
+
+## Recognition
+
+- **Advisory Credits**: Credit in GitHub Security Advisories (unless anonymous)
+
+## Security Updates
+
+**Stay Informed:**
+- Subscribe to GitHub releases for **nvm**
+- Enable GitHub Security Advisory notifications
+
+**Update Process:**
+- Patch releases (e.g., v0.40.3 → v0.40.4)
+- Out-of-band releases for critical issues
+- Advisories via GitHub Security Advisories
+
+## Contact Information
+
+- **Security reports**: Security tab of [nvm-sh/nvm](https://github.com/nvm-sh/nvm/security)
+- **General inquiries**: GitHub Discussions or Issues
+

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,6 +1,6 @@
 # Security
 
-Please email [@ljharb](https://github.com/ljharb) or see https://tidelift.com/security if you have a potential security vulnerability to report.
+Please file a private vulnerability report via GitHub, email [@ljharb](https://github.com/ljharb), or see https://tidelift.com/security if you have a potential security vulnerability to report.
 
 ## OpenSSF CII Best Practices
 
@@ -12,16 +12,17 @@ There are three “tiers”: passing, silver, and gold.
 We meet 100% of the “passing” criteria.
 
 ### Silver
-We meet 95% of the “silver” criteria. The gaps are as follows:
-  - we do not have a DCO or a CLA process for contributions.
-  - because we only have one maintainer, the project has no way to continue if that maintainer stops being active.
-  - we do not currently document “what the user can and cannot expect in terms of security” for our project. This is planned to be completed in 2023.
+We meet 100% of the “silver” criteria.
 
 ### Gold
-We meet 65% of the “gold” criteria. The gaps are as follows:
-  - we do not yet have the “silver” badge; see all the gaps above.
+We meet 78% of the “gold” criteria. The gaps are as follows:
+  - because we only have one maintainer, the project has no way to continue if that maintainer stops being active.
   - We do not include a copyright or license statement in each source file. Efforts are underway to change this archaic practice into a suggestion instead of a hard requirement.
 
 ## Threat Model
 
-See [THREAT_MODEL.md](./THREAT_MODEL.md).
+See [THREAT_MODEL.md](.github/THREAT_MODEL.md).
+
+## Incident Response Plan
+
+Please see our [Incident Response Plan](.github/INCIDENT_RESPONSE_PLAN.md).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </a>
 
 
-# Node Version Manager [![Build Status](https://app.travis-ci.com/nvm-sh/nvm.svg?branch=master)][3] [![nvm version](https://img.shields.io/badge/version-v0.40.2-yellow.svg)][4] [![CII Best Practices](https://bestpractices.dev/projects/684/badge)](https://bestpractices.dev/projects/684)
+# Node Version Manager [![Build Status](https://app.travis-ci.com/nvm-sh/nvm.svg?branch=master)][3] [![nvm version](https://img.shields.io/badge/version-v0.40.3-yellow.svg)][4] [![CII Best Practices](https://bestpractices.dev/projects/684/badge)](https://bestpractices.dev/projects/684)
 
 <!-- To update this table of contents, ensure you have run `npm install` then `npm run doctoc` -->
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
@@ -104,10 +104,10 @@ nvm is a version manager for [node.js](https://nodejs.org/en/), designed to be i
 
 To **install** or **update** nvm, you should run the [install script][2]. To do that, you may either download and run the script manually, or use the following cURL or Wget command:
 ```sh
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
 ```
 ```sh
-wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
+wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
 ```
 
 Running either of the above commands downloads a script and runs it. The script clones the nvm repository to `~/.nvm`, and attempts to add the source lines from the snippet below to the correct profile file (`~/.bashrc`, `~/.bash_profile`, `~/.zshrc`, or `~/.profile`). If you find the install script is updating the wrong profile file, set the `$PROFILE` env var to the profile file’s path, and then rerun the installation script.
@@ -134,7 +134,7 @@ Eg: `curl ... | NVM_DIR="path/to/nvm"`. Ensure that the `NVM_DIR` does not conta
 
 - The installer can use `git`, `curl`, or `wget` to download `nvm`, whichever is available.
 
-- You can instruct the installer to not edit your shell config (for example if you already get completions via a [zsh nvm plugin](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/nvm)) by setting `PROFILE=/dev/null` before running the `install.sh` script. Here's an example one-line command to do that: `PROFILE=/dev/null bash -c 'curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash'`
+- You can instruct the installer to not edit your shell config (for example if you already get completions via a [zsh nvm plugin](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/nvm)) by setting `PROFILE=/dev/null` before running the `install.sh` script. Here's an example one-line command to do that: `PROFILE=/dev/null bash -c 'curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash'`
 
 #### Installing in Docker
 
@@ -168,7 +168,7 @@ ARG NODE_VERSION=20
 RUN apt update && apt install curl -y
 
 # install nvm
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
 
 # set env
 ENV NVM_DIR=/root/.nvm
@@ -194,7 +194,7 @@ After creation of the image you can start container interactively and run comman
 docker run --rm -it nvmimage
 
 root@0a6b5a237c14:/# nvm -v
-0.40.2
+0.40.3
 
 root@0a6b5a237c14:/# node -v
 v19.9.0
@@ -257,7 +257,7 @@ You can use a task:
 ```yaml
 - name: Install nvm
   ansible.builtin.shell: >
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
   args:
     creates: "{{ ansible_env.HOME }}/.nvm/nvm.sh"
 ```
@@ -319,7 +319,7 @@ If you have `git` installed (requires git v1.7.10+):
 
 1. clone this repo in the root of your user profile
     - `cd ~/` from anywhere then `git clone https://github.com/nvm-sh/nvm.git .nvm`
-1. `cd ~/.nvm` and check out the latest version with `git checkout v0.40.2`
+1. `cd ~/.nvm` and check out the latest version with `git checkout v0.40.3`
 1. activate `nvm` by sourcing it from your shell: `. ./nvm.sh`
 
 Now add these lines to your `~/.bashrc`, `~/.profile`, or `~/.zshrc` file to have it automatically sourced upon login:
@@ -925,13 +925,13 @@ If installing nvm on Alpine Linux *is* still what you want or need to do, you sh
 ### Alpine Linux 3.13+
 ```sh
 apk add -U curl bash ca-certificates openssl ncurses coreutils python3 make gcc g++ libgcc linux-headers grep util-linux binutils findutils
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
 ```
 
 ### Alpine Linux 3.5 - 3.12
 ```sh
 apk add -U curl bash ca-certificates openssl ncurses coreutils python2 make gcc g++ libgcc linux-headers grep util-linux binutils findutils
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
 ```
 
 _Note: Alpine 3.5 can only install NodeJS versions up to v6.9.5, Alpine 3.6 can only install versions up to v6.10.3, Alpine 3.7 installs versions up to v8.9.3, Alpine 3.8 installs versions up to v8.14.0, Alpine 3.9 installs versions up to v10.19.0, Alpine 3.10 installs versions up to v10.24.1, Alpine 3.11 installs versions up to v12.22.6, Alpine 3.12 installs versions up to v12.22.12, Alpine 3.13 & 3.14 install versions up to v14.20.0, Alpine 3.15 & 3.16 install versions up to v16.16.0 (**These are all versions on the main branch**). Alpine 3.5 - 3.12 required the package `python2` to build NodeJS, as they are older versions to build. Alpine 3.13+ requires `python3` to successfully build newer NodeJS versions, but you can use `python2` with Alpine 3.13+ if you need to build versions of node supported in Alpine 3.5 - 3.15, you just need to specify what version of NodeJS you need to install in the package install script._
@@ -1034,9 +1034,9 @@ You have to make sure that the user directory name in `$HOME` and the user direc
 To change the user directory and/or account name follow the instructions [here](https://support.apple.com/en-us/HT201548)
 
 [1]: https://github.com/nvm-sh/nvm.git
-[2]: https://github.com/nvm-sh/nvm/blob/v0.40.2/install.sh
+[2]: https://github.com/nvm-sh/nvm/blob/v0.40.3/install.sh
 [3]: https://app.travis-ci.com/nvm-sh/nvm
-[4]: https://github.com/nvm-sh/nvm/releases/tag/v0.40.2
+[4]: https://github.com/nvm-sh/nvm/releases/tag/v0.40.3
 [Urchin]: https://git.sdf.org/tlevine/urchin
 [Fish]: https://fishshell.com
 
@@ -1094,7 +1094,7 @@ Here's what you will need to do:
   If one of these broken versions is installed on your system, the above step will likely still succeed even if you didn't include the `--shared-zlib` flag.
   However, later, when you attempt to `npm install` something using your old version of node.js, you will see `incorrect data check` errors.
   If you want to avoid the possible hassle of dealing with this, include that flag.
-  For more details, see [this issue](https://github.com/nodejs/node/issues/39313) and [this comment](https://github.com/nodejs/node/issues/39313#issuecomment-90.40.276)
+  For more details, see [this issue](https://github.com/nodejs/node/issues/39313) and [this comment](https://github.com/nodejs/node/issues/39313#issuecomment-90.40.376)
 
 - Exit back to your native shell.
 
@@ -1121,7 +1121,7 @@ Now you should be able to use node as usual.
 If you've encountered this error on WSL-2:
 
   ```sh
-  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                   Dload  Upload  Total   Spent    Left  Speed
   0     0    0     0    0     0      0      0 --:--:--  0:00:09 --:--:--     0curl: (6) Could not resolve host: raw.githubusercontent.com
@@ -1156,7 +1156,7 @@ Currently, the sole maintainer is [@ljharb](https://github.com/ljharb) - more ma
 
 ## Project Support
 
-Only the latest version (v0.40.2 at this time) is supported.
+Only the latest version (v0.40.3 at this time) is supported.
 
 ## Enterprise Support
 

--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,7 @@ nvm_install_dir() {
 }
 
 nvm_latest_version() {
-  nvm_echo "v0.40.2"
+  nvm_echo "v0.40.3"
 }
 
 nvm_profile_is_bash_or_zsh() {

--- a/nvm.sh
+++ b/nvm.sh
@@ -4438,7 +4438,7 @@ nvm() {
       NVM_VERSION_ONLY=true NVM_LTS="${NVM_LTS-}" nvm_remote_version "${PATTERN:-node}"
     ;;
     "--version" | "-v")
-      nvm_echo '0.40.2'
+      nvm_echo '0.40.3'
     ;;
     "unload")
       nvm deactivate >/dev/null 2>&1

--- a/nvm.sh
+++ b/nvm.sh
@@ -356,19 +356,19 @@ nvm_install_latest_npm() {
     if [ $NVM_IS_19_OR_ABOVE -eq 1 ] && nvm_version_greater_than_or_equal_to "${NODE_VERSION}" 20.5.0; then
       NVM_IS_20_5_OR_ABOVE=1
     fi
-    local NVM_IS_20_17_or_ABOVE
-    NVM_IS_20_17_or_ABOVE=0
-    if [ $NVM_IS_20_5_OR_ABOVE -eq 1 ] && nvm_version_greater 20.17.0 "${NODE_VERSION}"; then
-      NVM_IS_20_17_or_ABOVE=1
+    local NVM_IS_20_17_OR_ABOVE
+    NVM_IS_20_17_OR_ABOVE=0
+    if [ $NVM_IS_20_5_OR_ABOVE -eq 1 ] && nvm_version_greater_than_or_equal_to "${NODE_VERSION}" 20.17.0; then
+      NVM_IS_20_17_OR_ABOVE=1
     fi
     local NVM_IS_21_OR_ABOVE
     NVM_IS_21_OR_ABOVE=0
-    if [ $NVM_IS_20_17_or_ABOVE -eq 1 ] && nvm_version_greater 21.0.0 "${NODE_VERSION}"; then
+    if [ $NVM_IS_20_17_OR_ABOVE -eq 1 ] && nvm_version_greater_than_or_equal_to "${NODE_VERSION}" 21.0.0; then
       NVM_IS_21_OR_ABOVE=1
     fi
     local NVM_IS_22_9_OR_ABOVE
     NVM_IS_22_9_OR_ABOVE=0
-    if [ $NVM_IS_21_OR_ABOVE -eq 1 ] && nvm_version_greater 22.9.0 "${NODE_VERSION}"; then
+    if [ $NVM_IS_21_OR_ABOVE -eq 1 ] && nvm_version_greater_than_or_equal_to "${NODE_VERSION}" 22.9.0; then
       NVM_IS_22_9_OR_ABOVE=1
     fi
 
@@ -420,7 +420,7 @@ nvm_install_latest_npm() {
       nvm_echo '* `npm` `v9.x` is the last version that works on `node` `< v18.17`, `v19`, or `v20.0` - `v20.4`'
       $NVM_NPM_CMD install -g npm@9
     elif \
-      [ $NVM_IS_20_17_or_ABOVE -eq 0 ] \
+      [ $NVM_IS_20_17_OR_ABOVE -eq 0 ] \
       || { [ $NVM_IS_21_OR_ABOVE -eq 1 ] && [ $NVM_IS_22_9_OR_ABOVE -eq 0 ]; } \
     ; then
       nvm_echo '* `npm` `v10.x` is the last version that works on `node` `< v20.17`, `v21`, or `v22.0` - `v22.8`'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nvm",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "description": "Node Version Manager - Simple bash script to manage multiple active node.js versions",
   "directories": {
     "test": "test"


### PR DESCRIPTION
## Summary by Sourcery

Bump nvm to v0.40.3, refine security policy with a new incident response plan, and improve version comparison logic in the installer script.

New Features:
- Add a dedicated Incident Response Plan document under .github/INCIDENT_RESPONSE_PLAN.md

Bug Fixes:
- Fix version comparison conditions in nvm_install_latest_npm to correctly use 'greater than or equal to' checks

Enhancements:
- Update nvm.sh and install.sh to output the new version (v0.40.3)
- Standardize version variable naming (e.g., NVM_IS_20_17_OR_ABOVE) in nvm_install_latest_npm

Documentation:
- Bump README installation links, badges, and examples to v0.40.3
- Revise SECURITY.md to use private vulnerability reporting, update Best Practices stats, and correct the threat model link