### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nvm-install-test.yml
+++ b/.github/workflows/nvm-install-test.yml
@@ -1,4 +1,6 @@
 name: 'Tests: nvm install with set -e'
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/nvm/security/code-scanning/2](https://github.com/Dargon789/nvm/security/code-scanning/2)

The best fix is to add a `permissions:` block with minimal required access at the top of the workflow (global scope), so all jobs inherit it. For this workflow, only `contents: read` is needed (to check out and read code, fetch tags, etc.). No step writes to the repository or needs further permissions. This change should be made at the root of the YAML file, just after the workflow `name:` and before the `on:` key (usually line 2 or 3), affecting the entire workflow by default. No additional code, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Set contents: read permission at the top of the nvm-install-test workflow to comply with security scanning requirements