### PR TITLE
23 nvm offline version and cache resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,22 @@ nvm install-latest-npm
 If you've already gotten an error to the effect of "npm does not support Node.js", you'll need to (1) revert to a previous node version (`nvm ls` & `nvm use <your latest _working_ version from the ls>`), (2) delete the newly created node version (`nvm uninstall <your _broken_ version of node from the ls>`), then (3) rerun your `nvm install` with the `--latest-npm` flag.
 
 
+### Offline Install
+
+If you've previously downloaded a node version (or it's still in the cache), you can install it without any network access using the `--offline` flag:
+
+```sh
+nvm install --offline 14.7.0
+```
+
+This resolves versions using only locally installed versions and cached downloads. It will not attempt to download anything. This is useful in air-gapped environments, on planes, or when you want to avoid network latency.
+
+You can combine `--offline` with `--lts` to install the latest cached LTS version (as long as LTS aliases have been populated by a prior `nvm ls-remote --lts`):
+
+```sh
+nvm install --offline --lts
+```
+
 ### Default Global Packages From File While Installing
 
 If you have a list of default packages you want installed every time you install a new version, we support that too -- just add the package names, one per line, to the file `$NVM_DIR/default-packages`. You can add anything npm would accept as a package argument on the command line.

--- a/nvm.sh
+++ b/nvm.sh
@@ -1153,7 +1153,7 @@ nvm_print_formatted_alias() {
   fi
   local ARROW
   ARROW='->'
-  if nvm_has_colors; then
+  if [ "${NVM_HAS_COLORS-}" = 1 ] || nvm_has_colors; then
     ARROW='\033[0;90m->\033[0m'
     if [ "_${DEFAULT}" = '_true' ]; then
       NEWLINE=" \033[${DEFAULT_COLOR}(default)\033[0m\n"
@@ -1254,11 +1254,17 @@ nvm_list_aliases() {
     return $?
   fi
 
+  local NVM_HAS_COLORS
+  NVM_HAS_COLORS=0
+  if nvm_has_colors; then
+    NVM_HAS_COLORS=1
+  fi
+
   nvm_is_zsh && unsetopt local_options nomatch
   (
     local ALIAS_PATH
     for ALIAS_PATH in "${NVM_ALIAS_DIR}/${ALIAS}"*; do
-      NVM_NO_COLORS="${NVM_NO_COLORS-}" NVM_CURRENT="${NVM_CURRENT}" nvm_print_alias_path "${NVM_ALIAS_DIR}" "${ALIAS_PATH}" &
+      NVM_NO_COLORS="${NVM_NO_COLORS-}" NVM_HAS_COLORS="${NVM_HAS_COLORS}" NVM_CURRENT="${NVM_CURRENT}" nvm_print_alias_path "${NVM_ALIAS_DIR}" "${ALIAS_PATH}" &
     done
     wait
   ) | command sort
@@ -1269,7 +1275,7 @@ nvm_list_aliases() {
       {
         # shellcheck disable=SC2030,SC2031 # (https://github.com/koalaman/shellcheck/issues/2217)
         if [ ! -f "${NVM_ALIAS_DIR}/${ALIAS_NAME}" ] && { [ -z "${ALIAS}" ] || [ "${ALIAS_NAME}" = "${ALIAS}" ]; }; then
-          NVM_NO_COLORS="${NVM_NO_COLORS-}" NVM_CURRENT="${NVM_CURRENT}" nvm_print_default_alias "${ALIAS_NAME}"
+          NVM_NO_COLORS="${NVM_NO_COLORS-}" NVM_HAS_COLORS="${NVM_HAS_COLORS}" NVM_CURRENT="${NVM_CURRENT}" nvm_print_default_alias "${ALIAS_NAME}"
         fi
       } &
     done
@@ -1281,7 +1287,7 @@ nvm_list_aliases() {
     # shellcheck disable=SC2030,SC2031 # (https://github.com/koalaman/shellcheck/issues/2217)
     for ALIAS_PATH in "${NVM_ALIAS_DIR}/lts/${ALIAS}"*; do
       {
-        LTS_ALIAS="$(NVM_NO_COLORS="${NVM_NO_COLORS-}" NVM_LTS=true nvm_print_alias_path "${NVM_ALIAS_DIR}" "${ALIAS_PATH}")"
+        LTS_ALIAS="$(NVM_NO_COLORS="${NVM_NO_COLORS-}" NVM_HAS_COLORS="${NVM_HAS_COLORS}" NVM_LTS=true nvm_print_alias_path "${NVM_ALIAS_DIR}" "${ALIAS_PATH}")"
         if [ -n "${LTS_ALIAS}" ]; then
           nvm_echo "${LTS_ALIAS}"
         fi

--- a/nvm.sh
+++ b/nvm.sh
@@ -2490,22 +2490,35 @@ nvm_download_artifact() {
   local COMPRESSION
   COMPRESSION="$(nvm_get_artifact_compression "${VERSION}")"
 
-  local CHECKSUM
-  CHECKSUM="$(nvm_get_checksum "${FLAVOR}" "${TYPE}" "${VERSION}" "${SLUG}" "${COMPRESSION}")"
-
   local tmpdir
   if [ "${KIND}" = 'binary' ]; then
     tmpdir="$(nvm_cache_dir)/bin/${SLUG}"
   else
     tmpdir="$(nvm_cache_dir)/src/${SLUG}"
   fi
+
+  local TARBALL
+  TARBALL="${tmpdir}/${SLUG}.${COMPRESSION}"
+
+  if [ "${NVM_OFFLINE-}" = 1 ]; then
+    # In offline mode, use cached tarball without checksum or download
+    if [ -r "${TARBALL}" ]; then
+      nvm_err "Offline: using cached archive $(nvm_sanitize_path "${TARBALL}")"
+      nvm_echo "${TARBALL}"
+      return 0
+    fi
+    nvm_err "Offline: no cached archive found for ${SLUG}"
+    return 4
+  fi
+
+  local CHECKSUM
+  CHECKSUM="$(nvm_get_checksum "${FLAVOR}" "${TYPE}" "${VERSION}" "${SLUG}" "${COMPRESSION}")"
+
   command mkdir -p "${tmpdir}/files" || (
     nvm_err "creating directory ${tmpdir}/files failed"
     return 3
   )
 
-  local TARBALL
-  TARBALL="${tmpdir}/${SLUG}.${COMPRESSION}"
   local TARBALL_URL
   if nvm_version_greater_than_or_equal_to "${VERSION}" 0.1.14; then
     TARBALL_URL="${MIRROR}/${VERSION}/${SLUG}.${COMPRESSION}"
@@ -3050,6 +3063,57 @@ nvm_cache_dir() {
   nvm_echo "${NVM_DIR}/.cache"
 }
 
+# args: pattern
+# Lists versions available in the local cache (not yet installed).
+# Returns version numbers like "v18.20.4", one per line, sorted.
+nvm_ls_cached() {
+  local PATTERN
+  PATTERN="${1-}"
+  local CACHE_BIN_DIR
+  CACHE_BIN_DIR="$(nvm_cache_dir)/bin"
+  if [ ! -d "${CACHE_BIN_DIR}" ]; then
+    return
+  fi
+  local NVM_OS
+  NVM_OS="$(nvm_get_os)"
+  local NVM_ARCH
+  NVM_ARCH="$(nvm_get_arch)"
+  local SUFFIX
+  SUFFIX="${NVM_OS}-${NVM_ARCH}"
+  # shellcheck disable=SC2010
+  command ls -1 "${CACHE_BIN_DIR}" \
+    | nvm_grep "^node-v.*-${SUFFIX}\$" \
+    | command sed "s/^node-\\(v[0-9][0-9.]*\\)-${SUFFIX}\$/\\1/" \
+    | nvm_grep "$(nvm_ensure_version_prefix "${PATTERN}")" \
+    | command sort -t. -u -k 1.2,1n -k 2,2n -k 3,3n
+}
+
+# args: pattern
+# Resolves a version pattern to a single version using only locally
+# installed versions and cached downloads. No network access.
+nvm_offline_version() {
+  local PATTERN
+  PATTERN="${1-}"
+
+  # First try locally installed versions
+  local VERSION
+  VERSION="$(nvm_version "${PATTERN}")"
+  if [ "_${VERSION}" != '_N/A' ]; then
+    nvm_echo "${VERSION}"
+    return 0
+  fi
+
+  # Then try cached downloads
+  VERSION="$(nvm_ls_cached "${PATTERN}" | command tail -1)"
+  if [ -n "${VERSION}" ]; then
+    nvm_echo "${VERSION}"
+    return 0
+  fi
+
+  nvm_echo 'N/A'
+  return 3
+}
+
 nvm() {
   if [ "$#" -lt 1 ]; then
     nvm --help
@@ -3130,6 +3194,7 @@ nvm() {
         nvm_echo '    --skip-default-packages                   When installing, skip the default-packages file if it exists'
         nvm_echo '    --latest-npm                              After installing, attempt to upgrade to the latest working npm on the given node version'
         nvm_echo '    --no-progress                             Disable the progress bar on any downloads'
+        nvm_echo '    --offline                                  Install from cache only, without downloading anything'
         nvm_echo '    --alias=<name>                            After installing, set the alias specified to the version specified. (same as: nvm alias <name> <version>)'
         nvm_echo '    --default                                 After installing, set default alias to the version specified. (same as: nvm alias default <version>)'
         nvm_echo '    --save                                    After installing, write the specified version to .nvmrc'
@@ -3335,11 +3400,6 @@ nvm() {
       local NVM_OS
       NVM_OS="$(nvm_get_os)"
 
-      if ! nvm_has "curl" && ! nvm_has "wget"; then
-        nvm_err 'nvm needs curl or wget to proceed.'
-        return 1
-      fi
-
       if [ $# -lt 1 ]; then
         version_not_provided=1
       fi
@@ -3347,9 +3407,11 @@ nvm() {
       local nobinary
       local nosource
       local noprogress
+      local NVM_OFFLINE
       nobinary=0
       noprogress=0
       nosource=0
+      NVM_OFFLINE=0
       local LTS
       local ALIAS
       local NVM_UPGRADE_NPM
@@ -3390,6 +3452,10 @@ nvm() {
           ;;
           --no-progress)
             noprogress=1
+            shift
+          ;;
+          --offline)
+            NVM_OFFLINE=1
             shift
           ;;
           --lts)
@@ -3468,6 +3534,11 @@ nvm() {
         esac
       done
 
+      if [ "${NVM_OFFLINE}" != 1 ] && ! nvm_has "curl" && ! nvm_has "wget"; then
+        nvm_err 'nvm needs curl or wget to proceed.'
+        return 1
+      fi
+
       local provided_version
       provided_version="${1-}"
 
@@ -3505,8 +3576,27 @@ nvm() {
       esac
 
       local EXIT_CODE
-      VERSION="$(NVM_VERSION_ONLY=true NVM_LTS="${LTS-}" nvm_remote_version "${provided_version}")"
-      EXIT_CODE="$?"
+
+      if [ "${NVM_OFFLINE}" = 1 ]; then
+        local OFFLINE_PATTERN
+        OFFLINE_PATTERN="${provided_version}"
+        if [ -n "${LTS-}" ]; then
+          if [ "${LTS}" = '*' ]; then
+            OFFLINE_PATTERN="$(nvm_resolve_alias 'lts/*' 2>/dev/null || nvm_echo)"
+          else
+            OFFLINE_PATTERN="$(nvm_resolve_alias "lts/${LTS}" 2>/dev/null || nvm_echo)"
+          fi
+          if [ -z "${OFFLINE_PATTERN}" ]; then
+            nvm_err "LTS alias '${LTS}' not found locally. Run \`nvm ls-remote --lts\` first to populate LTS aliases."
+            return 3
+          fi
+        fi
+        VERSION="$(nvm_offline_version "${OFFLINE_PATTERN}")"
+        EXIT_CODE="$?"
+      else
+        VERSION="$(NVM_VERSION_ONLY=true NVM_LTS="${LTS-}" nvm_remote_version "${provided_version}")"
+        EXIT_CODE="$?"
+      fi
 
       if [ "${VERSION}" = 'N/A' ] || [ $EXIT_CODE -ne 0 ]; then
         local LTS_MSG
@@ -3522,9 +3612,17 @@ nvm() {
             return 3
           fi
         else
-          REMOTE_CMD='nvm ls-remote'
+          if [ "${NVM_OFFLINE}" = 1 ]; then
+            REMOTE_CMD='nvm ls'
+          else
+            REMOTE_CMD='nvm ls-remote'
+          fi
         fi
-        nvm_err "Version '${provided_version}' ${LTS_MSG-}not found - try \`${REMOTE_CMD}\` to browse available versions."
+        if [ "${NVM_OFFLINE}" = 1 ]; then
+          nvm_err "Version '${provided_version}' ${LTS_MSG-}not found locally or in cache - try \`${REMOTE_CMD}\` to browse available versions."
+        else
+          nvm_err "Version '${provided_version}' ${LTS_MSG-}not found - try \`${REMOTE_CMD}\` to browse available versions."
+        fi
         return 3
       fi
 
@@ -3664,7 +3762,7 @@ nvm() {
 
         # skip binary install if "nobinary" option specified.
         if [ $nobinary -ne 1 ] && nvm_binary_available "${VERSION}"; then
-          NVM_NO_PROGRESS="${NVM_NO_PROGRESS:-${noprogress}}" nvm_install_binary "${FLAVOR}" std "${VERSION}" "${nosource}"
+          NVM_NO_PROGRESS="${NVM_NO_PROGRESS:-${noprogress}}" NVM_OFFLINE="${NVM_OFFLINE}" nvm_install_binary "${FLAVOR}" std "${VERSION}" "${nosource}"
           EXIT_CODE=$?
         else
           EXIT_CODE=-1
@@ -3683,7 +3781,7 @@ nvm() {
             nvm_err 'Installing from source on non-WSL Windows is not supported'
             EXIT_CODE=87
           else
-            NVM_NO_PROGRESS="${NVM_NO_PROGRESS:-${noprogress}}" nvm_install_source "${FLAVOR}" std "${VERSION}" "${NVM_MAKE_JOBS}" "${ADDITIONAL_PARAMETERS}"
+            NVM_NO_PROGRESS="${NVM_NO_PROGRESS:-${noprogress}}" NVM_OFFLINE="${NVM_OFFLINE}" nvm_install_source "${FLAVOR}" std "${VERSION}" "${NVM_MAKE_JOBS}" "${ADDITIONAL_PARAMETERS}"
             EXIT_CODE=$?
           fi
         fi
@@ -4510,7 +4608,7 @@ nvm() {
         nvm_binary_available nvm_change_path nvm_strip_path \
         nvm_num_version_groups nvm_format_version nvm_ensure_version_prefix \
         nvm_normalize_version nvm_is_valid_version nvm_normalize_lts \
-        nvm_ensure_version_installed nvm_cache_dir \
+        nvm_ensure_version_installed nvm_cache_dir nvm_ls_cached nvm_offline_version \
         nvm_version_path nvm_alias_path nvm_version_dir \
         nvm_find_nvmrc nvm_find_up nvm_find_project_dir nvm_tree_contains_path \
         nvm_version_greater nvm_version_greater_than_or_equal_to \

--- a/nvm.sh
+++ b/nvm.sh
@@ -602,7 +602,6 @@ EOF
 }
 
 nvm_rc_version() {
-  export NVM_RC_VERSION=''
   local NVMRC_PATH
   NVMRC_PATH="$(nvm_find_nvmrc)"
   if [ ! -e "${NVMRC_PATH}" ]; then
@@ -612,7 +611,7 @@ nvm_rc_version() {
     return 1
   fi
 
-
+  local NVM_RC_VERSION
   if ! NVM_RC_VERSION="$(nvm_process_nvmrc "${NVMRC_PATH}")"; then
     return 1
   fi
@@ -626,6 +625,7 @@ nvm_rc_version() {
   if [ "${NVM_SILENT:-0}" -ne 1 ]; then
     nvm_echo "Found '${NVMRC_PATH}' with version <${NVM_RC_VERSION}>"
   fi
+  nvm_echo "${NVM_RC_VERSION}" >&3
 }
 
 nvm_clang_version() {
@@ -3483,14 +3483,11 @@ nvm() {
             shift
           fi
         else
-          nvm_rc_version
-          if [ $version_not_provided -eq 1 ] && [ -z "${NVM_RC_VERSION}" ]; then
-            unset NVM_RC_VERSION
+          { provided_version="$(nvm_rc_version 3>&1 1>&4)"; } 4>&1
+          if [ $version_not_provided -eq 1 ] && [ -z "${provided_version}" ]; then
             >&2 nvm --help
             return 127
           fi
-          provided_version="${NVM_RC_VERSION}"
-          unset NVM_RC_VERSION
         fi
       elif [ $# -gt 0 ]; then
         shift
@@ -3894,13 +3891,11 @@ nvm() {
       if [ -n "${NVM_LTS-}" ]; then
         VERSION="$(nvm_match_version "lts/${NVM_LTS:-*}")"
       elif [ -z "${PROVIDED_VERSION-}" ]; then
-        NVM_SILENT="${NVM_SILENT:-0}" nvm_rc_version
-        if [ -n "${NVM_RC_VERSION-}" ]; then
-          PROVIDED_VERSION="${NVM_RC_VERSION}"
+        { PROVIDED_VERSION="$(NVM_SILENT="${NVM_SILENT:-0}" nvm_rc_version 3>&1 1>&4)"; } 4>&1
+        if [ -n "${PROVIDED_VERSION}" ]; then
           IS_VERSION_FROM_NVMRC=1
           VERSION="$(nvm_version "${PROVIDED_VERSION}")"
         fi
-        unset NVM_RC_VERSION
         if [ -z "${VERSION}" ]; then
           nvm_err 'Please see `nvm --help` or https://github.com/nvm-sh/nvm#nvmrc for more information.'
           return 127
@@ -4028,11 +4023,11 @@ nvm() {
       done
 
       if [ $# -lt 1 ] && [ -z "${NVM_LTS-}" ]; then
-        NVM_SILENT="${NVM_SILENT:-0}" nvm_rc_version && has_checked_nvmrc=1
-        if [ -n "${NVM_RC_VERSION-}" ]; then
-          VERSION="$(nvm_version "${NVM_RC_VERSION-}")" ||:
+        local NVM_RC_VERSION
+        { NVM_RC_VERSION="$(NVM_SILENT="${NVM_SILENT:-0}" nvm_rc_version 3>&1 1>&4)"; } 4>&1 && has_checked_nvmrc=1
+        if [ -n "${NVM_RC_VERSION}" ]; then
+          VERSION="$(nvm_version "${NVM_RC_VERSION}")" ||:
         fi
-        unset NVM_RC_VERSION
         if [ "${VERSION:-N/A}" = 'N/A' ]; then
           >&2 nvm --help
           return 127
@@ -4046,12 +4041,11 @@ nvm() {
           if [ "_${VERSION:-N/A}" = '_N/A' ] && ! nvm_is_valid_version "${provided_version}"; then
             provided_version=''
             if [ $has_checked_nvmrc -ne 1 ]; then
-              NVM_SILENT="${NVM_SILENT:-0}" nvm_rc_version && has_checked_nvmrc=1
+              { NVM_RC_VERSION="$(NVM_SILENT="${NVM_SILENT:-0}" nvm_rc_version 3>&1 1>&4)"; } 4>&1 && has_checked_nvmrc=1
             fi
             provided_version="${NVM_RC_VERSION}"
             IS_VERSION_FROM_NVMRC=1
             VERSION="$(nvm_version "${NVM_RC_VERSION}")" ||:
-            unset NVM_RC_VERSION
           else
             shift
           fi
@@ -4112,9 +4106,7 @@ nvm() {
       elif [ -n "${provided_version}" ]; then
         VERSION="$(nvm_version "${provided_version}")" ||:
         if [ "_${VERSION}" = '_N/A' ] && ! nvm_is_valid_version "${provided_version}"; then
-          NVM_SILENT="${NVM_SILENT:-0}" nvm_rc_version && has_checked_nvmrc=1
-          provided_version="${NVM_RC_VERSION}"
-          unset NVM_RC_VERSION
+          { provided_version="$(NVM_SILENT="${NVM_SILENT:-0}" nvm_rc_version 3>&1 1>&4)"; } 4>&1 && has_checked_nvmrc=1
           VERSION="$(nvm_version "${provided_version}")" ||:
         else
           shift
@@ -4245,12 +4237,10 @@ nvm() {
         shift
       done
       if [ -z "${provided_version-}" ]; then
-        NVM_SILENT="${NVM_SILENT:-0}" nvm_rc_version
-        if [ -n "${NVM_RC_VERSION}" ]; then
-          provided_version="${NVM_RC_VERSION}"
-          VERSION=$(nvm_version "${NVM_RC_VERSION}") ||:
+        { provided_version="$(NVM_SILENT="${NVM_SILENT:-0}" nvm_rc_version 3>&1 1>&4)"; } 4>&1
+        if [ -n "${provided_version}" ]; then
+          VERSION=$(nvm_version "${provided_version}") ||:
         fi
-        unset NVM_RC_VERSION
       elif [ "${provided_version}" != 'system' ]; then
         VERSION="$(nvm_version "${provided_version}")" ||:
       else
@@ -4545,7 +4535,7 @@ nvm() {
         nvm_process_nvmrc nvm_nvmrc_invalid_msg \
         nvm_write_nvmrc \
         >/dev/null 2>&1
-      unset NVM_RC_VERSION NVM_NODEJS_ORG_MIRROR NVM_IOJS_ORG_MIRROR NVM_DIR \
+      unset NVM_NODEJS_ORG_MIRROR NVM_IOJS_ORG_MIRROR NVM_DIR \
         NVM_CD_FLAGS NVM_BIN NVM_INC NVM_MAKE_JOBS \
         NVM_COLORS INSTALLED_COLOR SYSTEM_COLOR \
         CURRENT_COLOR NOT_INSTALLED_COLOR DEFAULT_COLOR LTS_COLOR \
@@ -4677,7 +4667,7 @@ nvm_auto() {
           else
             return 0
           fi
-        elif nvm_rc_version >/dev/null 2>&1; then
+        elif nvm_rc_version 3>/dev/null >/dev/null 2>&1; then
           nvm use --silent >/dev/null
         fi
       else
@@ -4689,7 +4679,7 @@ nvm_auto() {
       VERSION="$(nvm_alias default 2>/dev/null || nvm_echo)"
       if [ -n "${VERSION}" ] && [ "_${VERSION}" != '_N/A' ] && nvm_is_valid_version "${VERSION}"; then
         nvm install "${VERSION}" >/dev/null
-      elif nvm_rc_version >/dev/null 2>&1; then
+      elif nvm_rc_version 3>/dev/null >/dev/null 2>&1; then
         nvm install >/dev/null
       else
         return 0

--- a/nvm.sh
+++ b/nvm.sh
@@ -3625,7 +3625,7 @@ nvm() {
           fi
         fi
         if [ "${NVM_OFFLINE}" = 1 ]; then
-          nvm_err "Version '${provided_version}' ${LTS_MSG-}not found locally or in cache - try \`${REMOTE_CMD}\` to browse available versions."
+          nvm_err "Version '${provided_version}' ${LTS_MSG-}not installed locally - try \`${REMOTE_CMD}\` to see installed versions and aliases."
         else
           nvm_err "Version '${provided_version}' ${LTS_MSG-}not found - try \`${REMOTE_CMD}\` to browse available versions."
         fi

--- a/test/common.sh
+++ b/test/common.sh
@@ -1,3 +1,29 @@
+# Runs a command once and captures stdout and exit code.
+# Suppresses xtrace in the subshell. Discards stderr.
+#
+# Sets: CAPTURED_STDOUT, CAPTURED_EXIT_CODE
+#
+# Usage:
+#   try nvm_version current
+#   [ "$CAPTURED_STDOUT" = "v20.0.0" ] || die "wrong output"
+#   [ "$CAPTURED_EXIT_CODE" = 0 ] || die "wrong exit code"
+try() {
+  CAPTURED_STDOUT="$(set +x; "$@" 2>/dev/null)" && CAPTURED_EXIT_CODE=0 || CAPTURED_EXIT_CODE=$?
+}
+
+# Runs a command once and captures stderr and exit code.
+# Suppresses xtrace in the subshell. Discards stdout.
+#
+# Sets: CAPTURED_STDERR, CAPTURED_EXIT_CODE
+#
+# Usage:
+#   try_err nvm_alias
+#   [ "$CAPTURED_STDERR" = "An alias is required." ] || die "wrong error"
+#   [ "$CAPTURED_EXIT_CODE" = 1 ] || die "wrong exit code"
+try_err() {
+  CAPTURED_STDERR="$(set +x; "$@" 2>&1 >/dev/null)" && CAPTURED_EXIT_CODE=0 || CAPTURED_EXIT_CODE=$?
+}
+
 assert_ok() {
   local FUNCTION=$1
   shift

--- a/test/fast/Aliases/'nvm alias' should not accept aliases with a hash
+++ b/test/fast/Aliases/'nvm alias' should not accept aliases with a hash
@@ -3,25 +3,21 @@
 : nvm.sh
 \. ../../../nvm.sh
 
+\. ../../common.sh
+
 die () { echo "$@" ; exit 1; }
 
-OUTPUT="$(nvm alias foo#bar baz 2>&1)"
+try_err nvm alias foo#bar baz
 EXPECTED_OUTPUT="Aliases with a comment delimiter (#) are not supported."
-[ "$OUTPUT" = "$EXPECTED_OUTPUT" ] || die "trying to create an alias with a hash should fail with '$EXPECTED_OUTPUT', got '$OUTPUT'"
+[ "$CAPTURED_STDERR" = "$EXPECTED_OUTPUT" ] || die "trying to create an alias with a hash should fail with '$EXPECTED_OUTPUT', got '$CAPTURED_STDERR'"
+[ "$CAPTURED_EXIT_CODE" = "1" ] || die "trying to create an alias with a hash should fail with code 1, got '$CAPTURED_EXIT_CODE'"
 
-EXIT_CODE="$(nvm alias foo#bar baz >/dev/null 2>&1 ; echo $?)"
-[ "$EXIT_CODE" = "1" ] || die "trying to create an alias with a hash should fail with code 1, got '$EXIT_CODE'"
-
-OUTPUT="$(nvm alias foo# baz 2>&1)"
+try_err nvm alias foo# baz
 EXPECTED_OUTPUT="Aliases with a comment delimiter (#) are not supported."
-[ "$OUTPUT" = "$EXPECTED_OUTPUT" ] || die "trying to create an alias ending with a hash should fail with '$EXPECTED_OUTPUT', got '$OUTPUT'"
+[ "$CAPTURED_STDERR" = "$EXPECTED_OUTPUT" ] || die "trying to create an alias ending with a hash should fail with '$EXPECTED_OUTPUT', got '$CAPTURED_STDERR'"
+[ "$CAPTURED_EXIT_CODE" = "1" ] || die "trying to create an alias ending with a hash should fail with code 1, got '$CAPTURED_EXIT_CODE'"
 
-EXIT_CODE="$(nvm alias foo# baz >/dev/null 2>&1 ; echo $?)"
-[ "$EXIT_CODE" = "1" ] || die "trying to create an alias ending with a hash should fail with code 1, got '$EXIT_CODE'"
-
-OUTPUT="$(nvm alias \#bar baz 2>&1)"
+try_err nvm alias \#bar baz
 EXPECTED_OUTPUT="Aliases with a comment delimiter (#) are not supported."
-[ "$OUTPUT" = "$EXPECTED_OUTPUT" ] || die "trying to create an alias starting with a hash should fail with '$EXPECTED_OUTPUT', got '$OUTPUT'"
-
-EXIT_CODE="$(nvm alias \#bar baz >/dev/null 2>&1 ; echo $?)"
-[ "$EXIT_CODE" = "1" ] || die "trying to create an alias starting with a hash should fail with code 1, got '$EXIT_CODE'"
+[ "$CAPTURED_STDERR" = "$EXPECTED_OUTPUT" ] || die "trying to create an alias starting with a hash should fail with '$EXPECTED_OUTPUT', got '$CAPTURED_STDERR'"
+[ "$CAPTURED_EXIT_CODE" = "1" ] || die "trying to create an alias starting with a hash should fail with code 1, got '$CAPTURED_EXIT_CODE'"

--- a/test/fast/Aliases/'nvm alias' should not accept aliases with slashes
+++ b/test/fast/Aliases/'nvm alias' should not accept aliases with slashes
@@ -3,25 +3,21 @@
 : nvm.sh
 \. ../../../nvm.sh
 
+\. ../../common.sh
+
 die () { echo "$@" ; exit 1; }
 
-OUTPUT="$(nvm alias foo/bar baz 2>&1)"
+try_err nvm alias foo/bar baz
 EXPECTED_OUTPUT="Aliases in subdirectories are not supported."
-[ "$OUTPUT" = "$EXPECTED_OUTPUT" ] || die "trying to create an alias with a slash should fail with '$EXPECTED_OUTPUT', got '$OUTPUT'"
+[ "$CAPTURED_STDERR" = "$EXPECTED_OUTPUT" ] || die "trying to create an alias with a slash should fail with '$EXPECTED_OUTPUT', got '$CAPTURED_STDERR'"
+[ "$CAPTURED_EXIT_CODE" = "1" ] || die "trying to create an alias with a slash should fail with code 1, got '$CAPTURED_EXIT_CODE'"
 
-EXIT_CODE="$(nvm alias foo/bar baz >/dev/null 2>&1 ; echo $?)"
-[ "$EXIT_CODE" = "1" ] || die "trying to create an alias with a slash should fail with code 1, got '$EXIT_CODE'"
-
-OUTPUT="$(nvm alias foo/ baz 2>&1)"
+try_err nvm alias foo/ baz
 EXPECTED_OUTPUT="Aliases in subdirectories are not supported."
-[ "$OUTPUT" = "$EXPECTED_OUTPUT" ] || die "trying to create an alias ending with a slash should fail with '$EXPECTED_OUTPUT', got '$OUTPUT'"
+[ "$CAPTURED_STDERR" = "$EXPECTED_OUTPUT" ] || die "trying to create an alias ending with a slash should fail with '$EXPECTED_OUTPUT', got '$CAPTURED_STDERR'"
+[ "$CAPTURED_EXIT_CODE" = "1" ] || die "trying to create an alias ending with a slash should fail with code 1, got '$CAPTURED_EXIT_CODE'"
 
-EXIT_CODE="$(nvm alias foo/ baz >/dev/null 2>&1 ; echo $?)"
-[ "$EXIT_CODE" = "1" ] || die "trying to create an alias ending with a slash should fail with code 1, got '$EXIT_CODE'"
-
-OUTPUT="$(nvm alias /bar baz 2>&1)"
+try_err nvm alias /bar baz
 EXPECTED_OUTPUT="Aliases in subdirectories are not supported."
-[ "$OUTPUT" = "$EXPECTED_OUTPUT" ] || die "trying to create an alias starting with a slash should fail with '$EXPECTED_OUTPUT', got '$OUTPUT'"
-
-EXIT_CODE="$(nvm alias /bar baz >/dev/null 2>&1 ; echo $?)"
-[ "$EXIT_CODE" = "1" ] || die "trying to create an alias starting with a slash should fail with code 1, got '$EXIT_CODE'"
+[ "$CAPTURED_STDERR" = "$EXPECTED_OUTPUT" ] || die "trying to create an alias starting with a slash should fail with '$EXPECTED_OUTPUT', got '$CAPTURED_STDERR'"
+[ "$CAPTURED_EXIT_CODE" = "1" ] || die "trying to create an alias starting with a slash should fail with code 1, got '$CAPTURED_EXIT_CODE'"

--- a/test/fast/Aliases/'nvm unalias' should not accept aliases with slashes
+++ b/test/fast/Aliases/'nvm unalias' should not accept aliases with slashes
@@ -3,25 +3,21 @@
 : nvm.sh
 \. ../../../nvm.sh
 
+\. ../../common.sh
+
 die () { echo "$@" ; exit 1; }
 
-OUTPUT="$(nvm unalias foo/bar 2>&1)"
+try_err nvm unalias foo/bar
 EXPECTED_OUTPUT="Aliases in subdirectories are not supported."
-[ "$OUTPUT" = "$EXPECTED_OUTPUT" ] || die "trying to remove an alias with a slash should fail with '$EXPECTED_OUTPUT', got '$OUTPUT'"
+[ "$CAPTURED_STDERR" = "$EXPECTED_OUTPUT" ] || die "trying to remove an alias with a slash should fail with '$EXPECTED_OUTPUT', got '$CAPTURED_STDERR'"
+[ "$CAPTURED_EXIT_CODE" = "1" ] || die "trying to remove an alias with a slash should fail with code 1, got '$CAPTURED_EXIT_CODE'"
 
-EXIT_CODE="$(nvm unalias foo/bar >/dev/null 2>&1 ; echo $?)"
-[ "$EXIT_CODE" = "1" ] || die "trying to remove an alias with a slash should fail with code 1, got '$EXIT_CODE'"
-
-OUTPUT="$(nvm unalias foo/ 2>&1)"
+try_err nvm unalias foo/
 EXPECTED_OUTPUT="Aliases in subdirectories are not supported."
-[ "$OUTPUT" = "$EXPECTED_OUTPUT" ] || die "trying to remove an alias ending with a slash should fail with '$EXPECTED_OUTPUT', got '$OUTPUT'"
+[ "$CAPTURED_STDERR" = "$EXPECTED_OUTPUT" ] || die "trying to remove an alias ending with a slash should fail with '$EXPECTED_OUTPUT', got '$CAPTURED_STDERR'"
+[ "$CAPTURED_EXIT_CODE" = "1" ] || die "trying to remove an alias ending with a slash should fail with code 1, got '$CAPTURED_EXIT_CODE'"
 
-EXIT_CODE="$(nvm unalias foo/ >/dev/null 2>&1 ; echo $?)"
-[ "$EXIT_CODE" = "1" ] || die "trying to remove an alias ending with a slash should fail with code 1, got '$EXIT_CODE'"
-
-OUTPUT="$(nvm unalias /bar 2>&1)"
+try_err nvm unalias /bar
 EXPECTED_OUTPUT="Aliases in subdirectories are not supported."
-[ "$OUTPUT" = "$EXPECTED_OUTPUT" ] || die "trying to remove an alias starting with a slash should fail with '$EXPECTED_OUTPUT', got '$OUTPUT'"
-
-EXIT_CODE="$(nvm unalias /bar >/dev/null 2>&1 ; echo $?)"
-[ "$EXIT_CODE" = "1" ] || die "trying to remove an alias starting with a slash should fail with code 1, got '$EXIT_CODE'"
+[ "$CAPTURED_STDERR" = "$EXPECTED_OUTPUT" ] || die "trying to remove an alias starting with a slash should fail with '$EXPECTED_OUTPUT', got '$CAPTURED_STDERR'"
+[ "$CAPTURED_EXIT_CODE" = "1" ] || die "trying to remove an alias starting with a slash should fail with code 1, got '$CAPTURED_EXIT_CODE'"

--- a/test/fast/Running 'nvm use foo' where 'foo' is circular aborts
+++ b/test/fast/Running 'nvm use foo' where 'foo' is circular aborts
@@ -11,30 +11,20 @@ cleanup() {
 : nvm.sh
 \. ../../nvm.sh
 
+\. ../common.sh
+
 nvm_make_alias foo foo
 
-set +ex # needed for stderr
-OUTPUT="$(nvm use foo 2>&1)"
-set -ex
+try_err nvm use foo
 EXPECTED_OUTPUT='The alias "foo" leads to an infinite loop. Aborting.'
-[ "_${OUTPUT}" = "_${EXPECTED_OUTPUT}" ] \
-  || die "'nvm use foo' did not output >${EXPECTED_OUTPUT}<; got >${OUTPUT}<"
+[ "_${CAPTURED_STDERR}" = "_${EXPECTED_OUTPUT}" ] \
+  || die "'nvm use foo' did not output >${EXPECTED_OUTPUT}<; got >${CAPTURED_STDERR}<"
+[ "_$CAPTURED_EXIT_CODE" = "_8" ] || die "Expected exit code 8; got ${CAPTURED_EXIT_CODE}"
 
-set +ex # needed for stderr
-EXIT_CODE="$(nvm use foo 2>/dev/null ; echo $?)"
-set -ex
-[ "_$EXIT_CODE" = "_8" ] || die "Expected exit code 8; got ${EXIT_CODE}"
-
-set +ex # needed for stderr
-OUTPUT="$(nvm use --silent foo 2>&1)"
-set -ex
+try_err nvm use --silent foo
 EXPECTED_OUTPUT=''
-[ "_${OUTPUT}" = "_${EXPECTED_OUTPUT}" ] \
-  || die "'nvm use --silent foo' did not output >${EXPECTED_OUTPUT}<; got >${OUTPUT}<"
-
-set +ex # needed for stderr
-EXIT_CODE="$(nvm use --silent foo 2>/dev/null ; echo $?)"
-set -ex
-[ $EXIT_CODE -eq 8 ] || die "Expected exit code 8 from 'nvm use --silent foo'; got ${EXIT_CODE}"
+[ "_${CAPTURED_STDERR}" = "_${EXPECTED_OUTPUT}" ] \
+  || die "'nvm use --silent foo' did not output >${EXPECTED_OUTPUT}<; got >${CAPTURED_STDERR}<"
+[ $CAPTURED_EXIT_CODE -eq 8 ] || die "Expected exit code 8 from 'nvm use --silent foo'; got ${CAPTURED_EXIT_CODE}"
 
 cleanup

--- a/test/fast/Running 'nvm use' should drop CR char automatically
+++ b/test/fast/Running 'nvm use' should drop CR char automatically
@@ -14,20 +14,17 @@ cleanup() {
 
 # normal .nvmrc
 printf '0.999.0\n'   > .nvmrc
-nvm_rc_version
-VERSION1="${NVM_RC_VERSION}"
+{ VERSION1="$(nvm_rc_version 3>&1 1>&4)"; } 4>&1
 
 # .nvmrc with CR char
 printf '0.999.0\r\n' > .nvmrc
-nvm_rc_version
-VERSION2="${NVM_RC_VERSION}"
+{ VERSION2="$(nvm_rc_version 3>&1 1>&4)"; } 4>&1
 
 [ "${VERSION1}" = "${VERSION2}" ]
 
 # .nvmrc without any newline char
 printf '0.999.0' > .nvmrc
-nvm_rc_version
-VERSION3="${NVM_RC_VERSION}"
+{ VERSION3="$(nvm_rc_version 3>&1 1>&4)"; } 4>&1
 
 [ "${VERSION1}" = "${VERSION3}" ]
 

--- a/test/fast/Unit tests/nvm install --offline
+++ b/test/fast/Unit tests/nvm install --offline
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+die () { echo "$@" ; exit 1; }
+
+\. ../../../nvm.sh
+
+\. ../../common.sh
+
+# Mock nvm_download to ensure no network access
+nvm_download() {
+  die "nvm_download should not be called in offline mode"
+}
+
+# --offline with an already-installed version should succeed
+INSTALLED_VERSION="$(nvm ls | command tail -1 | command awk '{print $1}' | command sed 's/\x1b\[[0-9;]*m//g')"
+if [ -n "${INSTALLED_VERSION}" ] && [ "_${INSTALLED_VERSION}" != '_N/A' ] && [ "_${INSTALLED_VERSION}" != '_system' ]; then
+  try nvm install --offline "${INSTALLED_VERSION}"
+  [ "_$CAPTURED_EXIT_CODE" = "_0" ] \
+    || die "nvm install --offline with installed version '${INSTALLED_VERSION}' should succeed, got exit code $CAPTURED_EXIT_CODE"
+fi
+
+# --offline with a nonexistent version should fail
+try_err nvm install --offline 999.999.999
+[ "_$CAPTURED_EXIT_CODE" != "_0" ] \
+  || die "nvm install --offline with nonexistent version should fail"
+
+EXPECTED_ERR="not found locally or in cache"
+nvm_echo "$CAPTURED_STDERR" | nvm_grep -q "${EXPECTED_ERR}" \
+  || die "nvm install --offline error should mention 'not found locally or in cache'; got '$CAPTURED_STDERR'"
+
+# --offline should not require curl or wget
+nvm_has() { return 1; }
+try_err nvm install --offline 999.999.999
+# Should fail with "not found" not "nvm needs curl or wget"
+nvm_echo "$CAPTURED_STDERR" | nvm_grep -q "curl or wget" \
+  && die "nvm install --offline should not require curl or wget"
+alias nvm_has='\nvm_has'
+unset -f nvm_has

--- a/test/fast/Unit tests/nvm_alias
+++ b/test/fast/Unit tests/nvm_alias
@@ -9,21 +9,19 @@ cleanup () {
 : nvm.sh
 \. ../../../nvm.sh
 
-OUTPUT="$(nvm_alias 2>&1)"
-EXPECTED_OUTPUT='An alias is required.'
-[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'nvm_alias' produced wrong output; got $OUTPUT"
+\. ../../common.sh
 
-EXIT_CODE="$(nvm_alias >/dev/null 2>&1 ; echo $?)"
-[ "_$EXIT_CODE" = "_1" ] || die "'nvm_alias' exited with $EXIT_CODE, expected 1"
+try_err nvm_alias
+EXPECTED_OUTPUT='An alias is required.'
+[ "_$CAPTURED_STDERR" = "_$EXPECTED_OUTPUT" ] || die "'nvm_alias' produced wrong output; got $CAPTURED_STDERR"
+[ "_$CAPTURED_EXIT_CODE" = "_1" ] || die "'nvm_alias' exited with $CAPTURED_EXIT_CODE, expected 1"
 
 rm -rf ../../../alias/nonexistent
 
-OUTPUT="$(nvm_alias nonexistent 2>&1)"
+try_err nvm_alias nonexistent
 EXPECTED_OUTPUT='Alias does not exist.'
-[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'nvm_alias nonexistent' produced wrong output; got $OUTPUT"
-
-EXIT_CODE="$(nvm_alias nonexistent >/dev/null 2>&1 ; echo $?)"
-[ "_$EXIT_CODE" = "_2" ] || die "'nvm_alias nonexistent' exited with $EXIT_CODE, expected 2"
+[ "_$CAPTURED_STDERR" = "_$EXPECTED_OUTPUT" ] || die "'nvm_alias nonexistent' produced wrong output; got $CAPTURED_STDERR"
+[ "_$CAPTURED_EXIT_CODE" = "_2" ] || die "'nvm_alias nonexistent' exited with $CAPTURED_EXIT_CODE, expected 2"
 
 EXPECTED_OUTPUT="0.10"
 nvm alias test "$EXPECTED_OUTPUT" || die "'nvm alias test $EXPECTED_OUTPUT' failed"

--- a/test/fast/Unit tests/nvm_compare_checksum
+++ b/test/fast/Unit tests/nvm_compare_checksum
@@ -8,66 +8,50 @@ die () { echo "$@" ; cleanup ; exit 1; }
 : nvm.sh
 \. ../../../nvm.sh
 
+\. ../../common.sh
+
 set -ex
 
 nvm_compute_checksum() {
   echo
 }
 
-set +x
-OUTPUT="$(nvm_compare_checksum 2>&1 >/dev/null || echo)"
-EXIT_CODE="$(nvm_compare_checksum >/dev/null 2>&1 || echo $?)"
-set -x
+try_err nvm_compare_checksum
 EXPECTED_OUTPUT='Provided file to checksum is empty.'
-[ "${OUTPUT}" = "${EXPECTED_OUTPUT}" ] || die "expected >${EXPECTED_OUTPUT}<, got >${OUTPUT}<"
-[ "${EXIT_CODE}" = 4 ] || die "expected to exit with code 4, got ${EXIT_CODE}"
+[ "${CAPTURED_STDERR}" = "${EXPECTED_OUTPUT}" ] || die "expected >${EXPECTED_OUTPUT}<, got >${CAPTURED_STDERR}<"
+[ "${CAPTURED_EXIT_CODE}" = 4 ] || die "expected to exit with code 4, got ${CAPTURED_EXIT_CODE}"
 
-set +x
-OUTPUT="$(nvm_compare_checksum foo 2>&1 >/dev/null || echo)"
-EXIT_CODE="$(nvm_compare_checksum foo >/dev/null 2>&1 || echo $?)"
-set -x
+try_err nvm_compare_checksum foo
 EXPECTED_OUTPUT='Provided file to checksum does not exist.'
-[ "${OUTPUT}" = "${EXPECTED_OUTPUT}" ] || die "expected >${EXPECTED_OUTPUT}<, got >${OUTPUT}<"
-[ "${EXIT_CODE}" = 3 ] || die "expected to exit with code 3, got ${EXIT_CODE}"
+[ "${CAPTURED_STDERR}" = "${EXPECTED_OUTPUT}" ] || die "expected >${EXPECTED_OUTPUT}<, got >${CAPTURED_STDERR}<"
+[ "${CAPTURED_EXIT_CODE}" = 3 ] || die "expected to exit with code 3, got ${CAPTURED_EXIT_CODE}"
 
-set +x
-OUTPUT="$(nvm_compare_checksum ../../../nvm.sh 2>&1 >/dev/null || echo)"
-EXIT_CODE="$(nvm_compare_checksum ../../../nvm.sh >/dev/null 2>&1 || echo $?)"
-set -x
+try_err nvm_compare_checksum ../../../nvm.sh
 EXPECTED_OUTPUT='Provided checksum to compare to is empty.'
-[ "${OUTPUT}" = "${EXPECTED_OUTPUT}" ] || die "expected >${EXPECTED_OUTPUT}<, got >${OUTPUT}<"
-[ "${EXIT_CODE}" = 2 ] || die "expected to exit with code 2, got ${EXIT_CODE}"
+[ "${CAPTURED_STDERR}" = "${EXPECTED_OUTPUT}" ] || die "expected >${EXPECTED_OUTPUT}<, got >${CAPTURED_STDERR}<"
+[ "${CAPTURED_EXIT_CODE}" = 2 ] || die "expected to exit with code 2, got ${CAPTURED_EXIT_CODE}"
 
-set +x
-OUTPUT="$(nvm_compare_checksum ../../../nvm.sh checksum 2>&1 >/dev/null)"
-EXIT_CODE="$(nvm_compare_checksum ../../../nvm.sh checksum >/dev/null 2>&1 ; echo $?)"
-set -x
+try_err nvm_compare_checksum ../../../nvm.sh checksum
 EXPECTED_OUTPUT="Computed checksum of '../../../nvm.sh' is empty.
 WARNING: Continuing *without checksum verification*"
-[ "${OUTPUT}" = "${EXPECTED_OUTPUT}" ] || die "expected >${EXPECTED_OUTPUT}<, got >${OUTPUT}<"
-[ "${EXIT_CODE}" = 0 ] || die "expected to exit with code 0, got ${EXIT_CODE}"
+[ "${CAPTURED_STDERR}" = "${EXPECTED_OUTPUT}" ] || die "expected >${EXPECTED_OUTPUT}<, got >${CAPTURED_STDERR}<"
+[ "${CAPTURED_EXIT_CODE}" = 0 ] || die "expected to exit with code 0, got ${CAPTURED_EXIT_CODE}"
 
 nvm_compute_checksum() {
   echo "not checksum: ${1}"
 }
 
-set +x
-OUTPUT="$(nvm_compare_checksum ../../../nvm.sh checksum 2>&1 >/dev/null || echo)"
-EXIT_CODE="$(nvm_compare_checksum ../../../nvm.sh checksum >/dev/null 2>&1 || echo $?)"
-set -x
+try_err nvm_compare_checksum ../../../nvm.sh checksum
 EXPECTED_OUTPUT="Checksums do not match: 'not checksum: ../../../nvm.sh' found, 'checksum' expected."
-[ "${OUTPUT}" = "${EXPECTED_OUTPUT}" ] || die "expected >${EXPECTED_OUTPUT}<, got >${OUTPUT}<"
-[ "${EXIT_CODE}" = 1 ] || die "expected to exit with code 1, got ${EXIT_CODE}"
+[ "${CAPTURED_STDERR}" = "${EXPECTED_OUTPUT}" ] || die "expected >${EXPECTED_OUTPUT}<, got >${CAPTURED_STDERR}<"
+[ "${CAPTURED_EXIT_CODE}" = 1 ] || die "expected to exit with code 1, got ${CAPTURED_EXIT_CODE}"
 
 nvm_compute_checksum() {
   echo checksum
 }
-set +x
-OUTPUT="$(nvm_compare_checksum ../../../nvm.sh checksum 2>&1 >/dev/null)"
-EXIT_CODE="$(nvm_compare_checksum ../../../nvm.sh checksum >/dev/null 2>&1; echo $?)"
-set -x
+try_err nvm_compare_checksum ../../../nvm.sh checksum
 EXPECTED_OUTPUT='Checksums matched!'
-[ "${OUTPUT}" = "${EXPECTED_OUTPUT}" ] || die "expected >${EXPECTED_OUTPUT}<, got >${OUTPUT}<"
-[ "${EXIT_CODE}" = 0 ] || die "expected to exit with code 0, got ${EXIT_CODE}"
+[ "${CAPTURED_STDERR}" = "${EXPECTED_OUTPUT}" ] || die "expected >${EXPECTED_OUTPUT}<, got >${CAPTURED_STDERR}<"
+[ "${CAPTURED_EXIT_CODE}" = 0 ] || die "expected to exit with code 0, got ${CAPTURED_EXIT_CODE}"
 
 cleanup

--- a/test/fast/Unit tests/nvm_compute_checksum
+++ b/test/fast/Unit tests/nvm_compute_checksum
@@ -7,18 +7,14 @@ die () { echo "$@" ; exit 1; }
 : nvm.sh
 \. ../../../nvm.sh
 
-set +x
-OUTPUT="$(nvm_compute_checksum 2>&1 >/dev/null || echo)"
-EXIT_CODE="$(nvm_compute_checksum >/dev/null 2>&1 || echo $?)"
-set -x
-EXPECTED_OUTPUT='Provided file to checksum is empty.'
-[ "${OUTPUT}" = "${EXPECTED_OUTPUT}" ] || die "expected >${EXPECTED_OUTPUT}<, got >${OUTPUT}<"
-[ "${EXIT_CODE}" = 2 ] || die "expected to exit with code 2, got ${EXIT_CODE}"
+\. ../../common.sh
 
-set +x
-OUTPUT="$(nvm_compute_checksum foo 2>&1 >/dev/null || echo)"
-EXIT_CODE="$(nvm_compute_checksum foo >/dev/null 2>&1 || echo $?)"
-set -x
+try_err nvm_compute_checksum
+EXPECTED_OUTPUT='Provided file to checksum is empty.'
+[ "${CAPTURED_STDERR}" = "${EXPECTED_OUTPUT}" ] || die "expected >${EXPECTED_OUTPUT}<, got >${CAPTURED_STDERR}<"
+[ "${CAPTURED_EXIT_CODE}" = 2 ] || die "expected to exit with code 2, got ${CAPTURED_EXIT_CODE}"
+
+try_err nvm_compute_checksum foo
 EXPECTED_OUTPUT='Provided file to checksum does not exist.'
-[ "${OUTPUT}" = "${EXPECTED_OUTPUT}" ] || die "expected >${EXPECTED_OUTPUT}<, got >${OUTPUT}<"
-[ "${EXIT_CODE}" = 1 ] || die "expected to exit with code 1, got ${EXIT_CODE}"
+[ "${CAPTURED_STDERR}" = "${EXPECTED_OUTPUT}" ] || die "expected >${EXPECTED_OUTPUT}<, got >${CAPTURED_STDERR}<"
+[ "${CAPTURED_EXIT_CODE}" = 1 ] || die "expected to exit with code 1, got ${CAPTURED_EXIT_CODE}"

--- a/test/fast/Unit tests/nvm_die_on_prefix
+++ b/test/fast/Unit tests/nvm_die_on_prefix
@@ -6,6 +6,8 @@ TEST_DIR="$TEST_PWD/nvm_die_on_prefix_tmp"
 : nvm.sh
 \. ../../../nvm.sh
 
+\. ../../common.sh
+
 TEST_VERSION_DIR="${TEST_DIR}/version"
 
 cleanup () {
@@ -23,23 +25,20 @@ die () {
 
 [ ! -e "$TEST_DIR" ] && mkdir "$TEST_DIR"
 
-OUTPUT="$(nvm_die_on_prefix 2>&1)"
+try_err nvm_die_on_prefix
 EXPECTED_OUTPUT="First argument \"delete the prefix\" must be zero or one"
-EXIT_CODE="$(nvm_die_on_prefix >/dev/null 2>&1; echo $?)"
-[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix' did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
-[ "_$EXIT_CODE" = "_1" ] || die "'nvm_die_on_prefix' did not exit with 1; got "$EXIT_CODE""
+[ "_$CAPTURED_STDERR" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix' did not error with '$EXPECTED_OUTPUT'; got '$CAPTURED_STDERR'"
+[ "_$CAPTURED_EXIT_CODE" = "_1" ] || die "'nvm_die_on_prefix' did not exit with 1; got "$CAPTURED_EXIT_CODE""
 
-OUTPUT="$(nvm_die_on_prefix 2 2>&1)"
+try_err nvm_die_on_prefix 2
 EXPECTED_OUTPUT="First argument \"delete the prefix\" must be zero or one"
-EXIT_CODE="$(nvm_die_on_prefix 2 >/dev/null 2>&1; echo $?)"
-[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 2' did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
-[ "_$EXIT_CODE" = "_1" ] || die "'nvm_die_on_prefix' did not exit with 1; got "$EXIT_CODE""
+[ "_$CAPTURED_STDERR" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 2' did not error with '$EXPECTED_OUTPUT'; got '$CAPTURED_STDERR'"
+[ "_$CAPTURED_EXIT_CODE" = "_1" ] || die "'nvm_die_on_prefix' did not exit with 1; got "$CAPTURED_EXIT_CODE""
 
-OUTPUT="$(nvm_die_on_prefix 0 2>&1)"
+try_err nvm_die_on_prefix 0
 EXPECTED_OUTPUT='Second argument "nvm command", and third argument "nvm version dir", must both be nonempty'
-EXIT_CODE="$(nvm_die_on_prefix 0 >/dev/null 2>&1; echo $?)"
-[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0' did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
-[ "_$EXIT_CODE" = "_2" ] || die "'nvm_die_on_prefix 0' did not exit with 2; got '$EXIT_CODE'"
+[ "_$CAPTURED_STDERR" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0' did not error with '$EXPECTED_OUTPUT'; got '$CAPTURED_STDERR'"
+[ "_$CAPTURED_EXIT_CODE" = "_2" ] || die "'nvm_die_on_prefix 0' did not exit with 2; got '$CAPTURED_EXIT_CODE'"
 
 nvm_has() { return 1; } # ie, npm is not installed
 OUTPUT="$(nvm_die_on_prefix 0 version_dir foo 2>&1)"
@@ -70,26 +69,26 @@ node() {
 OUTPUT="$(nvm_die_on_prefix 0 foo "$(nvm_version_dir new)" 2>&1)"
 [ -z "$OUTPUT" ] || die "'nvm_die_on_prefix' was not a noop when directory is equivalent; got '$OUTPUT'"
 
-OUTPUT="$(PREFIX=bar nvm_die_on_prefix 0 foo "$(nvm_version_dir new)" 2>&1)"
+PREFIX=bar try_err nvm_die_on_prefix 0 foo "$(nvm_version_dir new)"
+unset PREFIX
 EXPECTED_OUTPUT='nvm is not compatible with the "PREFIX" environment variable: currently set to "bar"
 Run `unset PREFIX` to unset it.'
-EXIT_CODE="$(export PREFIX=bar ; nvm_die_on_prefix 0 foo "$(nvm_version_dir new)" >/dev/null 2>&1; echo $?)"
-[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'PREFIX=bar nvm_die_on_prefix 0 foo' did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
-[ "_$EXIT_CODE" = "_3" ] || die "'PREFIX=bar nvm_die_on_prefix 0 foo' did not exit with 3; got '$EXIT_CODE'"
+[ "_$CAPTURED_STDERR" = "_$EXPECTED_OUTPUT" ] || die "'PREFIX=bar nvm_die_on_prefix 0 foo' did not error with '$EXPECTED_OUTPUT'; got '$CAPTURED_STDERR'"
+[ "_$CAPTURED_EXIT_CODE" = "_3" ] || die "'PREFIX=bar nvm_die_on_prefix 0 foo' did not exit with 3; got '$CAPTURED_EXIT_CODE'"
 
-OUTPUT="$(export NPM_CONFIG_PREFIX=bar ; nvm_die_on_prefix 0 foo "$(nvm_version_dir new)" 2>&1)"
+NPM_CONFIG_PREFIX=bar try_err nvm_die_on_prefix 0 foo "$(nvm_version_dir new)"
+unset NPM_CONFIG_PREFIX
 EXPECTED_OUTPUT='nvm is not compatible with the "NPM_CONFIG_PREFIX" environment variable: currently set to "bar"
 Run `unset NPM_CONFIG_PREFIX` to unset it.'
-EXIT_CODE="$(export NPM_CONFIG_PREFIX=bar ; nvm_die_on_prefix 0 foo "$(nvm_version_dir new)" >/dev/null 2>&1; echo $?)"
-[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'NPM_CONFIG_PREFIX=bar nvm_die_on_prefix 0 foo' did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
-[ "_$EXIT_CODE" = "_4" ] || die "'NPM_CONFIG_PREFIX=bar nvm_die_on_prefix 0 foo' did not exit with 4; got '$EXIT_CODE'"
+[ "_$CAPTURED_STDERR" = "_$EXPECTED_OUTPUT" ] || die "'NPM_CONFIG_PREFIX=bar nvm_die_on_prefix 0 foo' did not error with '$EXPECTED_OUTPUT'; got '$CAPTURED_STDERR'"
+[ "_$CAPTURED_EXIT_CODE" = "_4" ] || die "'NPM_CONFIG_PREFIX=bar nvm_die_on_prefix 0 foo' did not exit with 4; got '$CAPTURED_EXIT_CODE'"
 
-OUTPUT="$(export npm_CONFIG_PREFIX=bar ; nvm_die_on_prefix 0 foo "$(nvm_version_dir new)" 2>&1)"
+npm_CONFIG_PREFIX=bar try_err nvm_die_on_prefix 0 foo "$(nvm_version_dir new)"
+unset npm_CONFIG_PREFIX
 EXPECTED_OUTPUT='nvm is not compatible with the "npm_CONFIG_PREFIX" environment variable: currently set to "bar"
 Run `unset npm_CONFIG_PREFIX` to unset it.'
-EXIT_CODE="$(export npm_CONFIG_PREFIX=bar ; nvm_die_on_prefix 0 foo "$(nvm_version_dir new)" >/dev/null 2>&1; echo $?)"
-[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'npm_CONFIG_PREFIX=bar nvm_die_on_prefix 0 foo' did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
-[ "_$EXIT_CODE" = "_4" ] || die "'npm_CONFIG_PREFIX=bar nvm_die_on_prefix 0 foo' did not exit with 4; got '$EXIT_CODE'"
+[ "_$CAPTURED_STDERR" = "_$EXPECTED_OUTPUT" ] || die "'npm_CONFIG_PREFIX=bar nvm_die_on_prefix 0 foo' did not error with '$EXPECTED_OUTPUT'; got '$CAPTURED_STDERR'"
+[ "_$CAPTURED_EXIT_CODE" = "_4" ] || die "'npm_CONFIG_PREFIX=bar nvm_die_on_prefix 0 foo' did not exit with 4; got '$CAPTURED_EXIT_CODE'"
 
 OUTPUT="$(export FOO='This contains NPM_CONFIG_PREFIX' ; nvm_die_on_prefix 0 foo "$(nvm_version_dir new)" 2>&1)"
 [ -z "$OUTPUT" ] || die "'nvm_die_on_prefix' was not a noop; got '$OUTPUT'"
@@ -101,23 +100,21 @@ OUTPUT="$(export FOO='This contains NPM_CONFIG_PREFIX' ; nvm_die_on_prefix 0 foo
 
   # project: prefix
   echo 'prefix=garbage' > .npmrc
-  OUTPUT="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" 2>&1)"
+  try_err nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}"
   EXPECTED_OUTPUT="Your project npmrc file ($(nvm_sanitize_path "${TEST_DIR}")/.npmrc)
 has a \`globalconfig\` and/or a \`prefix\` setting, which are incompatible with nvm.
 Run \`foo\` to unset it."
-  EXIT_CODE="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" >/dev/null 2>&1; echo $?)"
-  [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0 foo' with project .npmrc that has prefix did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
-  [ "_$EXIT_CODE" = "_10" ] || die "'nvm_die_on_prefix 0 foo' with project .npmrc that has prefix did not exit with 10; got '$EXIT_CODE'"
+  [ "_$CAPTURED_STDERR" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0 foo' with project .npmrc that has prefix did not error with '$EXPECTED_OUTPUT'; got '$CAPTURED_STDERR'"
+  [ "_$CAPTURED_EXIT_CODE" = "_10" ] || die "'nvm_die_on_prefix 0 foo' with project .npmrc that has prefix did not exit with 10; got '$CAPTURED_EXIT_CODE'"
 
   # project: globalconfig
   echo 'globalconfig=garbage' > .npmrc
-  OUTPUT="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" 2>&1)"
+  try_err nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}"
   EXPECTED_OUTPUT="Your project npmrc file ($(nvm_sanitize_path "${TEST_DIR}")/.npmrc)
 has a \`globalconfig\` and/or a \`prefix\` setting, which are incompatible with nvm.
 Run \`foo\` to unset it."
-  EXIT_CODE="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" >/dev/null 2>&1; echo $?)"
-  [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0 foo' with project .npmrc that has globalconfig did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
-  [ "_$EXIT_CODE" = "_10" ] || die "'nvm_die_on_prefix 0 foo' with project .npmrc that has globalconfig did not exit with 10; got '$EXIT_CODE'"
+  [ "_$CAPTURED_STDERR" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0 foo' with project .npmrc that has globalconfig did not error with '$EXPECTED_OUTPUT'; got '$CAPTURED_STDERR'"
+  [ "_$CAPTURED_EXIT_CODE" = "_10" ] || die "'nvm_die_on_prefix 0 foo' with project .npmrc that has globalconfig did not exit with 10; got '$CAPTURED_EXIT_CODE'"
 
   rm "${TEST_DIR}/.npmrc" || die '.npmrc could not be removed'
 
@@ -133,67 +130,61 @@ Run \`foo\` to unset it."
 
   # global: prefix
   echo 'prefix=garbage' > "${GLOBAL_NPMRC}"
-  OUTPUT="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" 2>&1)"
+  try_err nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}"
   EXPECTED_OUTPUT="Your global npmrc file ($(nvm_sanitize_path "${GLOBAL_NPMRC}"))
 has a \`globalconfig\` and/or a \`prefix\` setting, which are incompatible with nvm.
 Run \`foo\` to unset it."
-  EXIT_CODE="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" >/dev/null 2>&1; echo $?)"
-  [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0 foo' with global npmrc that has prefix did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
-  [ "_$EXIT_CODE" = "_10" ] || die "'nvm_die_on_prefix 0 foo' with global npmrc that has prefix did not exit with 10; got '$EXIT_CODE'"
+  [ "_$CAPTURED_STDERR" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0 foo' with global npmrc that has prefix did not error with '$EXPECTED_OUTPUT'; got '$CAPTURED_STDERR'"
+  [ "_$CAPTURED_EXIT_CODE" = "_10" ] || die "'nvm_die_on_prefix 0 foo' with global npmrc that has prefix did not exit with 10; got '$CAPTURED_EXIT_CODE'"
 
   # global: globalconfig
   echo 'globalconfig=garbage' > "${GLOBAL_NPMRC}"
-  OUTPUT="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" 2>&1)"
+  try_err nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}"
   EXPECTED_OUTPUT="Your global npmrc file ($(nvm_sanitize_path "${GLOBAL_NPMRC}"))
 has a \`globalconfig\` and/or a \`prefix\` setting, which are incompatible with nvm.
 Run \`foo\` to unset it."
-  EXIT_CODE="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" >/dev/null 2>&1; echo $?)"
-  [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0 foo' with global npmrc that has globalconfig did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
-  [ "_$EXIT_CODE" = "_10" ] || die "'nvm_die_on_prefix 0 foo' with global npmrc that has globalconfig did not exit with 10; got '$EXIT_CODE'"
+  [ "_$CAPTURED_STDERR" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0 foo' with global npmrc that has globalconfig did not error with '$EXPECTED_OUTPUT'; got '$CAPTURED_STDERR'"
+  [ "_$CAPTURED_EXIT_CODE" = "_10" ] || die "'nvm_die_on_prefix 0 foo' with global npmrc that has globalconfig did not exit with 10; got '$CAPTURED_EXIT_CODE'"
 
   rm "${GLOBAL_NPMRC}" || die "${GLOBAL_NPMRC} could not be removed"
 
   # builtin: prefix
   echo 'prefix=garbage' > "${BUILTIN_NPMRC}"
-  OUTPUT="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" 2>&1)"
+  try_err nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}"
   EXPECTED_OUTPUT="Your builtin npmrc file ($(nvm_sanitize_path "${BUILTIN_NPMRC}"))
 has a \`globalconfig\` and/or a \`prefix\` setting, which are incompatible with nvm.
 Run \`foo\` to unset it."
-  EXIT_CODE="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" >/dev/null 2>&1; echo $?)"
-  [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0 foo' with builtin npmrc that has prefix did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
-  [ "_$EXIT_CODE" = "_10" ] || die "'nvm_die_on_prefix 0 foo' with builtin npmrc that has prefix did not exit with 10; got '$EXIT_CODE'"
+  [ "_$CAPTURED_STDERR" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0 foo' with builtin npmrc that has prefix did not error with '$EXPECTED_OUTPUT'; got '$CAPTURED_STDERR'"
+  [ "_$CAPTURED_EXIT_CODE" = "_10" ] || die "'nvm_die_on_prefix 0 foo' with builtin npmrc that has prefix did not exit with 10; got '$CAPTURED_EXIT_CODE'"
 
   # builtin: globalconfig
   echo 'globalconfig=garbage' > "${BUILTIN_NPMRC}"
-  OUTPUT="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" 2>&1)"
+  try_err nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}"
   EXPECTED_OUTPUT="Your builtin npmrc file ($(nvm_sanitize_path "${BUILTIN_NPMRC}"))
 has a \`globalconfig\` and/or a \`prefix\` setting, which are incompatible with nvm.
 Run \`foo\` to unset it."
-  EXIT_CODE="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" >/dev/null 2>&1; echo $?)"
-  [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0 foo' with builtin npmrc that has globalconfig did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
-  [ "_$EXIT_CODE" = "_10" ] || die "'nvm_die_on_prefix 0 foo' with builtin npmrc that has globalconfig did not exit with 10; got '$EXIT_CODE'"
+  [ "_$CAPTURED_STDERR" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0 foo' with builtin npmrc that has globalconfig did not error with '$EXPECTED_OUTPUT'; got '$CAPTURED_STDERR'"
+  [ "_$CAPTURED_EXIT_CODE" = "_10" ] || die "'nvm_die_on_prefix 0 foo' with builtin npmrc that has globalconfig did not exit with 10; got '$CAPTURED_EXIT_CODE'"
 
   rm "${BUILTIN_NPMRC}" || die "${BUILTIN_NPMRC} could not be removed"
 
   # user: prefix
   echo 'prefix=garbage' > "${USER_NPMRC}"
-  OUTPUT="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" 2>&1)"
+  try_err nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}"
   EXPECTED_OUTPUT="Your user’s .npmrc file ($(nvm_sanitize_path "${USER_NPMRC}"))
 has a \`globalconfig\` and/or a \`prefix\` setting, which are incompatible with nvm.
 Run \`foo\` to unset it."
-  EXIT_CODE="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" >/dev/null 2>&1; echo $?)"
-  [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0 foo' with user .npmrc that has prefix did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
-  [ "_$EXIT_CODE" = "_10" ] || die "'nvm_die_on_prefix 0 foo' with user .npmrc that has prefix did not exit with 10; got '$EXIT_CODE'"
+  [ "_$CAPTURED_STDERR" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0 foo' with user .npmrc that has prefix did not error with '$EXPECTED_OUTPUT'; got '$CAPTURED_STDERR'"
+  [ "_$CAPTURED_EXIT_CODE" = "_10" ] || die "'nvm_die_on_prefix 0 foo' with user .npmrc that has prefix did not exit with 10; got '$CAPTURED_EXIT_CODE'"
 
   # user: globalconfig
   echo 'globalconfig=garbage' > "${USER_NPMRC}"
-  OUTPUT="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" 2>&1)"
+  try_err nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}"
   EXPECTED_OUTPUT="Your user’s .npmrc file ($(nvm_sanitize_path "${USER_NPMRC}"))
 has a \`globalconfig\` and/or a \`prefix\` setting, which are incompatible with nvm.
 Run \`foo\` to unset it."
-  EXIT_CODE="$(nvm_die_on_prefix 0 foo "${TEST_VERSION_DIR}" >/dev/null 2>&1; echo $?)"
-  [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0 foo' with user .npmrc that has globalconfig did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
-  [ "_$EXIT_CODE" = "_10" ] || die "'nvm_die_on_prefix 0 foo' with user .npmrc that has globalconfig did not exit with 10; got '$EXIT_CODE'"
+  [ "_$CAPTURED_STDERR" = "_$EXPECTED_OUTPUT" ] || die "'nvm_die_on_prefix 0 foo' with user .npmrc that has globalconfig did not error with '$EXPECTED_OUTPUT'; got '$CAPTURED_STDERR'"
+  [ "_$CAPTURED_EXIT_CODE" = "_10" ] || die "'nvm_die_on_prefix 0 foo' with user .npmrc that has globalconfig did not exit with 10; got '$CAPTURED_EXIT_CODE'"
 )
 
 cleanup

--- a/test/fast/Unit tests/nvm_get_checksum
+++ b/test/fast/Unit tests/nvm_get_checksum
@@ -12,17 +12,16 @@ set +e # TODO: fix
 \. ../../../nvm.sh
 set -e
 
+\. ../../common.sh
+
 nvm_get_mirror() {
   echo "mirror-${1}-${2}"
 }
 
-set +ex # needed to capture error output
-OUTPUT="$(nvm_get_checksum 2>&1 >/dev/null)"
+try_err nvm_get_checksum
 EXPECTED_OUTPUT='supported flavors: node, iojs'
-EXIT_CODE="$(nvm_get_checksum >/dev/null 2>&1 ; echo $?)"
-set -ex
-[ "${OUTPUT}" = "${EXPECTED_OUTPUT}" ] || die "expected error output >${EXPECTED_OUTPUT}<, got >${OUTPUT}<"
-[ "${EXIT_CODE}" = 2 ] || die "expected exit code 2, got ${EXIT_CODE}"
+[ "${CAPTURED_STDERR}" = "${EXPECTED_OUTPUT}" ] || die "expected error output >${EXPECTED_OUTPUT}<, got >${CAPTURED_STDERR}<"
+[ "${CAPTURED_EXIT_CODE}" = 2 ] || die "expected exit code 2, got ${CAPTURED_EXIT_CODE}"
 
 nvm_download() {
   echo "ERROR_FAILED_MATCH no_match more fields"

--- a/test/fast/Unit tests/nvm_get_latest missing curl or wget
+++ b/test/fast/Unit tests/nvm_get_latest missing curl or wget
@@ -9,13 +9,14 @@ cleanup() {
 : nvm.sh
 \. ../../../nvm.sh
 
+\. ../../common.sh
+
 nvm_has() { return 1 ; }
 
-OUTPUT="$(nvm_get_latest 2>&1)"
-EXIT_CODE="$(nvm_get_latest >/dev/null 2>&1 ; echo $?)"
-[ "_$OUTPUT" = "_nvm needs curl or wget to proceed." ] \
-  || die "no curl/wget did not report correct error message, got '$OUTPUT'"
-[ "_$EXIT_CODE" = "_1" ] \
-  || die "no curl/wget did not exit with code 1, got $EXIT_CODE"
+try_err nvm_get_latest
+[ "_$CAPTURED_STDERR" = "_nvm needs curl or wget to proceed." ] \
+  || die "no curl/wget did not report correct error message, got '$CAPTURED_STDERR'"
+[ "_$CAPTURED_EXIT_CODE" = "_1" ] \
+  || die "no curl/wget did not exit with code 1, got $CAPTURED_EXIT_CODE"
 
 cleanup

--- a/test/fast/Unit tests/nvm_get_minor_version
+++ b/test/fast/Unit tests/nvm_get_minor_version
@@ -5,6 +5,8 @@ die () { echo "$@" ; exit 1; }
 : nvm.sh
 \. ../../../nvm.sh
 
+\. ../../common.sh
+
 expect () {
   INPUT="$1"
   EXPECTED_OUTPUT="$2"
@@ -20,8 +22,8 @@ fail_with () {
   INPUT="$1"
   EXPECTED_CODE="$2"
 
-  EXIT_CODE="$(nvm_get_minor_version "$INPUT" >/dev/null 2>&1; echo $?)"
-  [ "_$EXIT_CODE" = "_$EXPECTED_CODE" ] || die "nvm_get_minor_version "$INPUT" did not fail with code "$EXPECTED_CODE"; got $EXIT_CODE"
+  try nvm_get_minor_version "$INPUT"
+  [ "_$CAPTURED_EXIT_CODE" = "_$EXPECTED_CODE" ] || die "nvm_get_minor_version "$INPUT" did not fail with code "$EXPECTED_CODE"; got $CAPTURED_EXIT_CODE"
 }
 
 expect 1 1.0

--- a/test/fast/Unit tests/nvm_install_latest_npm
+++ b/test/fast/Unit tests/nvm_install_latest_npm
@@ -22,11 +22,10 @@ npm() {
   echo '1.2.3'
 }
 
-OUTPUT="$(nvm_install_latest_npm 2>&1 >/dev/null)"
-EXIT_CODE="$(nvm_install_latest_npm >/dev/null 2>&1 ; echo $?)"
+try_err nvm_install_latest_npm
 
 EXPECTED="Unable to obtain node version."
-[ "${OUTPUT}" = "${EXPECTED}" ] || die "When node is unavailable, expected >${EXPECTED}<; got >${OUTPUT}"
+[ "${CAPTURED_STDERR}" = "${EXPECTED}" ] || die "When node is unavailable, expected >${EXPECTED}<; got >${CAPTURED_STDERR}"
 
 node() {
   echo 'v4.5.6'
@@ -37,11 +36,10 @@ nvm_ls_current() {
 npm() {
   return 1
 }
-OUTPUT="$(nvm_install_latest_npm 2>&1 >/dev/null)"
-EXIT_CODE="$(nvm_install_latest_npm >/dev/null 2>&1 ; echo $?)"
+try_err nvm_install_latest_npm
 
 EXPECTED="Unable to obtain npm version."
-[ "${OUTPUT}" = "${EXPECTED}" ] || die "When node is available and npm is unavailable, expected >${EXPECTED}<; got >${OUTPUT}"
+[ "${CAPTURED_STDERR}" = "${EXPECTED}" ] || die "When node is available and npm is unavailable, expected >${EXPECTED}<; got >${CAPTURED_STDERR}"
 
 node() {
   echo 'v4.5.6'
@@ -52,8 +50,7 @@ nvm_ls_current() {
 npm() {
   return 1
 }
-OUTPUT="$(nvm_install_latest_npm 2>&1 >/dev/null)"
-EXIT_CODE="$(nvm_install_latest_npm >/dev/null 2>&1 ; echo $?)"
+try_err nvm_install_latest_npm
 
 EXPECTED="Unable to obtain npm version."
-[ "${OUTPUT}" = "${EXPECTED}" ] || die "When node is system and npm is unavailable, expected >${EXPECTED}<; got >${OUTPUT}"
+[ "${CAPTURED_STDERR}" = "${EXPECTED}" ] || die "When node is system and npm is unavailable, expected >${EXPECTED}<; got >${CAPTURED_STDERR}"

--- a/test/fast/Unit tests/nvm_ls_remote
+++ b/test/fast/Unit tests/nvm_ls_remote
@@ -19,10 +19,11 @@ nvm_download() {
 
 EXPECTED_OUTPUT_PATH="$MOCKS_DIR/nvm_ls_remote.txt"
 
-OUTPUT="$(nvm_ls_remote foo)"
-EXIT_CODE="$(nvm_ls_remote foo >/dev/null 2>&1 ; echo $?)"
-[ "_$OUTPUT" = "_N/A" ] || die "nonexistent version did not report N/A"
-[ "_$EXIT_CODE" = "_3" ] || die "nonexistent version did not exit with code 3, got $EXIT_CODE"
+\. ../../common.sh
+
+try nvm_ls_remote foo
+[ "_$CAPTURED_STDOUT" = "_N/A" ] || die "nonexistent version did not report N/A"
+[ "_$CAPTURED_EXIT_CODE" = "_3" ] || die "nonexistent version did not exit with code 3, got $CAPTURED_EXIT_CODE"
 
 OUTPUT="$(nvm_ls_remote)"
 EXPECTED_OUTPUT="$(cat "$EXPECTED_OUTPUT_PATH")"

--- a/test/fast/Unit tests/nvm_ls_remote nightly
+++ b/test/fast/Unit tests/nvm_ls_remote nightly
@@ -19,10 +19,11 @@ nvm_download() {
 
 EXPECTED_OUTPUT_PATH="$MOCKS_DIR/nvm_ls_remote nightly.txt"
 
-OUTPUT="$(nvm_ls_remote foo)"
-EXIT_CODE="$(nvm_ls_remote foo >/dev/null 2>&1 ; echo $?)"
-[ "_$OUTPUT" = "_N/A" ] || die "nonexistent version did not report N/A"
-[ "_$EXIT_CODE" = "_3" ] || die "nonexistent version did not exit with code 3, got $EXIT_CODE"
+\. ../../common.sh
+
+try nvm_ls_remote foo
+[ "_$CAPTURED_STDOUT" = "_N/A" ] || die "nonexistent version did not report N/A"
+[ "_$CAPTURED_EXIT_CODE" = "_3" ] || die "nonexistent version did not exit with code 3, got $CAPTURED_EXIT_CODE"
 
 OUTPUT="$(nvm_ls_remote)"
 EXPECTED_OUTPUT="$(cat "$EXPECTED_OUTPUT_PATH")"

--- a/test/fast/Unit tests/nvm_ls_remote_iojs
+++ b/test/fast/Unit tests/nvm_ls_remote_iojs
@@ -17,10 +17,11 @@ nvm_download() {
 
 EXPECTED_OUTPUT_PATH="$PWD/mocks/nvm_ls_remote_iojs.txt"
 
-OUTPUT="$(nvm_ls_remote_iojs foo)"
-EXIT_CODE="$(nvm_ls_remote_iojs foo >/dev/null 2>&1 ; echo $?)"
-[ "_$OUTPUT" = "_N/A" ] || die "nonexistent version did not report N/A"
-[ "_$EXIT_CODE" = "_3" ] || die "nonexistent version did not exit with code 3, got $EXIT_CODE"
+\. ../../common.sh
+
+try nvm_ls_remote_iojs foo
+[ "_$CAPTURED_STDOUT" = "_N/A" ] || die "nonexistent version did not report N/A"
+[ "_$CAPTURED_EXIT_CODE" = "_3" ] || die "nonexistent version did not exit with code 3, got $CAPTURED_EXIT_CODE"
 
 OUTPUT="$(nvm_ls_remote_iojs)"
 EXPECTED_OUTPUT="$(cat "$EXPECTED_OUTPUT_PATH")"

--- a/test/fast/Unit tests/nvm_make_alias
+++ b/test/fast/Unit tests/nvm_make_alias
@@ -5,16 +5,16 @@ die () { echo "$@" ; exit 1; }
 : nvm.sh
 \. ../../../nvm.sh
 
-OUTPUT="$(nvm_make_alias 2>&1)"
-EXIT_CODE="$(nvm_make_alias >/dev/null 2>&1 ; echo $?)"
+\. ../../common.sh
+
+try_err nvm_make_alias
 EXPECTED_OUTPUT='an alias name is required'
 
-[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "\`nvm_make_alias\` did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
-[ "$EXIT_CODE" -eq 1 ] || die "\`nvm_make_alias\` did not exit with 1, got '$EXIT_CODE'"
+[ "_$CAPTURED_STDERR" = "_$EXPECTED_OUTPUT" ] || die "\`nvm_make_alias\` did not error with '$EXPECTED_OUTPUT'; got '$CAPTURED_STDERR'"
+[ "$CAPTURED_EXIT_CODE" -eq 1 ] || die "\`nvm_make_alias\` did not exit with 1, got '$CAPTURED_EXIT_CODE'"
 
-OUTPUT="$(nvm_make_alias foo 2>&1)"
-EXIT_CODE="$(nvm_make_alias foo >/dev/null 2>&1 ; echo $?)"
+try_err nvm_make_alias foo
 EXPECTED_OUTPUT='an alias target version is required'
 
-[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "\`nvm_make_alias foo\` did not error with '$EXPECTED_OUTPUT'; got '$OUTPUT'"
-[ "$EXIT_CODE" -eq 2 ] || die "\`nvm_make_alias foo\` did not exit with 2, got '$EXIT_CODE'"
+[ "_$CAPTURED_STDERR" = "_$EXPECTED_OUTPUT" ] || die "\`nvm_make_alias foo\` did not error with '$EXPECTED_OUTPUT'; got '$CAPTURED_STDERR'"
+[ "$CAPTURED_EXIT_CODE" -eq 2 ] || die "\`nvm_make_alias foo\` did not exit with 2, got '$CAPTURED_EXIT_CODE'"

--- a/test/fast/Unit tests/nvm_offline_version
+++ b/test/fast/Unit tests/nvm_offline_version
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+die () { echo "$@" ; cleanup ; exit 1; }
+
+\. ../../../nvm.sh
+
+\. ../../common.sh
+
+TEST_DIR="$(pwd)/nvm_offline_version_tmp"
+
+cleanup() {
+  rm -rf "${TEST_DIR}"
+}
+
+[ ! -e "${TEST_DIR}" ] && mkdir -p "${TEST_DIR}"
+
+# nvm_offline_version should find installed versions
+INSTALLED_VERSION="$(nvm_version node)"
+if [ "_${INSTALLED_VERSION}" != '_N/A' ] && [ "_${INSTALLED_VERSION}" != '_system' ]; then
+  try nvm_offline_version "${INSTALLED_VERSION}"
+  [ "_$CAPTURED_STDOUT" = "_${INSTALLED_VERSION}" ] \
+    || die "nvm_offline_version '${INSTALLED_VERSION}' should return '${INSTALLED_VERSION}'; got '$CAPTURED_STDOUT'"
+  [ "_$CAPTURED_EXIT_CODE" = "_0" ] \
+    || die "nvm_offline_version '${INSTALLED_VERSION}' should exit 0; got '$CAPTURED_EXIT_CODE'"
+fi
+
+# nvm_offline_version with nonexistent version should return N/A
+try nvm_offline_version "999.999.999"
+[ "_$CAPTURED_STDOUT" = "_N/A" ] \
+  || die "nvm_offline_version '999.999.999' should return 'N/A'; got '$CAPTURED_STDOUT'"
+[ "_$CAPTURED_EXIT_CODE" = "_3" ] \
+  || die "nvm_offline_version '999.999.999' should exit 3; got '$CAPTURED_EXIT_CODE'"
+
+# nvm_ls_cached with nonexistent pattern should return nothing
+try nvm_ls_cached "999.999"
+[ -z "$CAPTURED_STDOUT" ] \
+  || die "nvm_ls_cached '999.999' should return empty; got '$CAPTURED_STDOUT'"
+
+cleanup

--- a/test/fast/Unit tests/nvm_print_alias_path
+++ b/test/fast/Unit tests/nvm_print_alias_path
@@ -24,12 +24,11 @@ nvm_alias() {
   echo ''
 }
 
-OUTPUT="$(nvm_print_alias_path "$NVM_ALIAS_DIR" foo | strip_colors)"
+try nvm_print_alias_path "$NVM_ALIAS_DIR" foo
+OUTPUT="$(echo "$CAPTURED_STDOUT" | strip_colors)"
 EXPECTED_OUTPUT=''
 [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'nvm_print_alias_path \"\$NVM_ALIAS_DIR\" foo' should produce no output when nvm_alias does not; got '$OUTPUT'"
-
-EXIT_CODE="$(nvm_print_alias_path "$NVM_ALIAS_DIR" foo >/dev/null 2>&1 ; echo $?)"
-[ "$EXIT_CODE" = '0' ] || die "'nvm_print_alias_path \"\$NVM_ALIAS_DIR\" foo' should exit zero when nvm_alias produces no output; got $EXIT_CODE"
+[ "$CAPTURED_EXIT_CODE" = '0' ] || die "'nvm_print_alias_path \"\$NVM_ALIAS_DIR\" foo' should exit zero when nvm_alias produces no output; got $CAPTURED_EXIT_CODE"
 
 nvm_alias() {
   echo "\"$1\""

--- a/test/fast/Unit tests/nvm_print_default_alias
+++ b/test/fast/Unit tests/nvm_print_default_alias
@@ -18,12 +18,11 @@ OUTPUT="$(nvm_print_default_alias 2>&1)"
 EXPECTED_OUTPUT='A default alias is required.'
 [ "$OUTPUT" = "$EXPECTED_OUTPUT" ] || die "'nvm_print_default_alias' produced wrong output; got '$OUTPUT', expected '$EXPECTED_OUTPUT'"
 
-OUTPUT="$(nvm_print_default_alias foo | strip_colors)"
+try nvm_print_default_alias foo
+OUTPUT="$(echo "$CAPTURED_STDOUT" | strip_colors)"
 EXPECTED_OUTPUT=''
 [ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "'nvm_print_default_alias foo' should produce no output when nvm_print_implicit_alias does not; got '$OUTPUT'"
-
-EXIT_CODE="$(nvm_print_default_alias foo >/dev/null 2>&1 ; echo $?)"
-[ "$EXIT_CODE" = '0' ] || die "'nvm_print_default_alias foo' should exit zero when nvm_print_implicit_alias produces no output; got $EXIT_CODE"
+[ "$CAPTURED_EXIT_CODE" = '0' ] || die "'nvm_print_default_alias foo' should exit zero when nvm_print_implicit_alias produces no output; got $CAPTURED_EXIT_CODE"
 
 nvm_print_implicit_alias() {
   echo "\"$1-$2\""

--- a/test/fast/Unit tests/nvm_print_implicit_alias errors
+++ b/test/fast/Unit tests/nvm_print_implicit_alias errors
@@ -5,15 +5,17 @@ die () { echo "$@" ; exit 1; }
 : nvm.sh
 \. ../../../nvm.sh
 
+\. ../../common.sh
+
 EXPECTED_FIRST_MSG="nvm_print_implicit_alias must be specified with local or remote as the first argument."
 [ "_$(nvm_print_implicit_alias 2>&1)" = "_$EXPECTED_FIRST_MSG" ] \
   || die "nvm_print_implicit_alias did not require local|remote as first argument"
 [ "_$(nvm_print_implicit_alias foo 2>&1)" = "_$EXPECTED_FIRST_MSG" ] \
   || die "nvm_print_implicit_alias did not require local|remote as first argument"
 
-FIRST_EXIT_CODE="$(nvm_print_implicit_alias > /dev/null 2>&1 ; echo $?)"
-[ "_$FIRST_EXIT_CODE" = "_1" ] \
-  || die "nvm_print_implicit_alias without local|remote had wrong exit code: expected 1, got $FIRST_EXIT_CODE"
+try_err nvm_print_implicit_alias
+[ "_$CAPTURED_EXIT_CODE" = "_1" ] \
+  || die "nvm_print_implicit_alias without local|remote had wrong exit code: expected 1, got $CAPTURED_EXIT_CODE"
 
 EXPECTED_SECOND_MSG="Only implicit aliases 'stable', 'unstable', 'iojs', and 'node' are supported."
 [ "_$(nvm_print_implicit_alias local 2>&1)" = "_$EXPECTED_SECOND_MSG" ] \
@@ -21,6 +23,6 @@ EXPECTED_SECOND_MSG="Only implicit aliases 'stable', 'unstable', 'iojs', and 'no
 [ "_$(nvm_print_implicit_alias local foo 2>&1)" = "_$EXPECTED_SECOND_MSG" ] \
   || die "nvm_print_implicit_alias did not require stable|unstable|iojs|node as second argument"
 
-SECOND_EXIT_CODE="$(nvm_print_implicit_alias local > /dev/null 2>&1 ; echo $?)"
-[ "_$SECOND_EXIT_CODE" = "_2" ] \
-  || die "nvm_print_implicit_alias without stable|unstable|iojs|node had wrong exit code: expected 2, got $SECOND_EXIT_CODE"
+try_err nvm_print_implicit_alias local
+[ "_$CAPTURED_EXIT_CODE" = "_2" ] \
+  || die "nvm_print_implicit_alias without stable|unstable|iojs|node had wrong exit code: expected 2, got $CAPTURED_EXIT_CODE"

--- a/test/fast/Unit tests/nvm_process_nvmrc
+++ b/test/fast/Unit tests/nvm_process_nvmrc
@@ -12,24 +12,23 @@ cleanup() {
 \. ../../common.sh
 
 for f in ../../../test/fixtures/nvmrc/test/fixtures/valid/*; do
-  STDOUT="$(nvm_process_nvmrc $f/.nvmrc 2>/dev/null)"
-  EXIT_CODE="$(nvm_process_nvmrc $f/.nvmrc >/dev/null 2>/dev/null; echo $?)"
+  try nvm_process_nvmrc $f/.nvmrc
 
   EXPECTED="$(nvm_json_extract node < "${f}/expected.json" | tr -d '"')"
 
-  [ "${EXIT_CODE}" = "0" ] || die "$(basename "${f}"): expected exit code of 0 but got ${EXIT_CODE}"
+  [ "${CAPTURED_EXIT_CODE}" = "0" ] || die "$(basename "${f}"): expected exit code of 0 but got ${CAPTURED_EXIT_CODE}"
 
-  [ "${STDOUT}" = "${EXPECTED}" ] || die "$(basename "${f}"): expected STDOUT of \`${EXPECTED}\` but got \`${STDOUT}\`"
+  [ "${CAPTURED_STDOUT}" = "${EXPECTED}" ] || die "$(basename "${f}"): expected STDOUT of \`${EXPECTED}\` but got \`${CAPTURED_STDOUT}\`"
 done
 
 for f in ../../../test/fixtures/nvmrc/test/fixtures/invalid/*; do
-  STDOUT="$(nvm_process_nvmrc $f/.nvmrc 2>/dev/null)"
-  STDERR="$(nvm_process_nvmrc $f/.nvmrc 2>&1 >/dev/null | awk '{if(NR > 8) print $0}' | strip_colors)"
-  EXIT_CODE="$(nvm_process_nvmrc $f/.nvmrc >/dev/null 2>/dev/null; echo $?)"
+  try nvm_process_nvmrc $f/.nvmrc
+  try_err nvm_process_nvmrc $f/.nvmrc
+  STDERR="$(echo "$CAPTURED_STDERR" | awk '{if(NR > 8) print $0}' | strip_colors)"
 
   EXPECTED="$(nvm_json_extract < "${f}/expected.json" | tr -d '"')"
 
-  [ "${EXIT_CODE}" != "0" ] || die "$(basename "${f}"): expected exit code of 'not 0' but got ${EXIT_CODE}"
+  [ "${CAPTURED_EXIT_CODE}" != "0" ] || die "$(basename "${f}"): expected exit code of 'not 0' but got ${CAPTURED_EXIT_CODE}"
 
   [ "${STDERR}" = "${EXPECTED}" ] || die "$(basename "${f}"): expected STDERR of \`${EXPECTED}\` but got \`${STDERR}\`"
 done

--- a/test/fast/Unit tests/nvm_remote_version
+++ b/test/fast/Unit tests/nvm_remote_version
@@ -9,21 +9,21 @@ cleanup() {
 : nvm.sh
 \. ../../../nvm.sh
 
+\. ../../common.sh
+
 nvm_ls_remote() {
   echo "N/A"
 }
-OUTPUT="$(nvm_remote_version foo)"
-EXIT_CODE="$(nvm_remote_version foo >/dev/null 2>&1 ; echo $?)"
-[ "_$OUTPUT" = "_N/A" ] || die "nonexistent version did not report N/A"
-[ "_$EXIT_CODE" = "_3" ] || die "nonexistent version did not exit with code 3, got $EXIT_CODE"
+try nvm_remote_version foo
+[ "_$CAPTURED_STDOUT" = "_N/A" ] || die "nonexistent version did not report N/A"
+[ "_$CAPTURED_EXIT_CODE" = "_3" ] || die "nonexistent version did not exit with code 3, got $CAPTURED_EXIT_CODE"
 
 nvm_ls_remote_iojs() {
   echo "N/A"
 }
-OUTPUT="$(nvm_remote_version iojs-foo)"
-EXIT_CODE="$(nvm_remote_version iojs-foo >/dev/null 2>&1 ; echo $?)"
-[ "_$OUTPUT" = "_N/A" ] || die "nonexistent version did not report N/A"
-[ "_$EXIT_CODE" = "_3" ] || die "nonexistent version did not exit with code 3, got $EXIT_CODE"
+try nvm_remote_version iojs-foo
+[ "_$CAPTURED_STDOUT" = "_N/A" ] || die "nonexistent version did not report N/A"
+[ "_$CAPTURED_EXIT_CODE" = "_3" ] || die "nonexistent version did not exit with code 3, got $CAPTURED_EXIT_CODE"
 
 
 nvm_ls_remote() {
@@ -40,41 +40,35 @@ nvm_ls_remote_iojs() {
     echo "iojs_pattern_received:_$1_"
   fi
 }
-OUTPUT="$(nvm_remote_version foo)"
-EXIT_CODE="$(nvm_remote_version foo >/dev/null 2>&1 ; echo $?)"
-[ "_$OUTPUT" = "_pattern_received:_foo_" ] \
-  || die "nvm_remote_version foo did not return last line only of nvm_ls_remote foo; got $OUTPUT"
-[ "_$EXIT_CODE" = "_0" ] || die "nvm_remote_version foo did not exit with 0, got $EXIT_CODE"
+try nvm_remote_version foo
+[ "_$CAPTURED_STDOUT" = "_pattern_received:_foo_" ] \
+  || die "nvm_remote_version foo did not return last line only of nvm_ls_remote foo; got $CAPTURED_STDOUT"
+[ "_$CAPTURED_EXIT_CODE" = "_0" ] || die "nvm_remote_version foo did not exit with 0, got $CAPTURED_EXIT_CODE"
 
-OUTPUT="$(nvm_remote_version iojs-foo)"
-EXIT_CODE="$(nvm_remote_version iojs-foo >/dev/null 2>&1 ; echo $?)"
-[ "_$OUTPUT" = "_iojs_pattern_received:_iojs-foo_" ] \
-  || die "nvm_remote_version iojs-foo did not return last line only of nvm_ls_remote_iojs foo; got $OUTPUT"
-[ "_$EXIT_CODE" = "_0" ] || die "nvm_remote_version iojs-foo did not exit with 0, got $EXIT_CODE"
+try nvm_remote_version iojs-foo
+[ "_$CAPTURED_STDOUT" = "_iojs_pattern_received:_iojs-foo_" ] \
+  || die "nvm_remote_version iojs-foo did not return last line only of nvm_ls_remote_iojs foo; got $CAPTURED_STDOUT"
+[ "_$CAPTURED_EXIT_CODE" = "_0" ] || die "nvm_remote_version iojs-foo did not exit with 0, got $CAPTURED_EXIT_CODE"
 
-OUTPUT="$(nvm_remote_version iojs)"
-EXIT_CODE="$(nvm_remote_version iojs >/dev/null 2>&1 ; echo $?)"
-[ "_$OUTPUT" = "_iojs_pattern_received:__" ] \
-  || die "nvm_remote_version iojs did not return last line only of nvm_ls_remote_iojs; got $OUTPUT"
-[ "_$EXIT_CODE" = "_0" ] || die "nvm_remote_version iojs did not exit with 0, got $EXIT_CODE"
+try nvm_remote_version iojs
+[ "_$CAPTURED_STDOUT" = "_iojs_pattern_received:__" ] \
+  || die "nvm_remote_version iojs did not return last line only of nvm_ls_remote_iojs; got $CAPTURED_STDOUT"
+[ "_$CAPTURED_EXIT_CODE" = "_0" ] || die "nvm_remote_version iojs did not exit with 0, got $CAPTURED_EXIT_CODE"
 
-OUTPUT="$(nvm_remote_version stable)"
-EXIT_CODE="$(nvm_remote_version stable >/dev/null 2>&1 ; echo $?)"
-[ "_$OUTPUT" = "_$(nvm_ls_remote stable)" ] \
-  || die "nvm_remote_version stable did not return contents of nvm_ls_remote stable; got $OUTPUT"
-[ "_$EXIT_CODE" = "_0" ] || die "nvm_remote_version stable did not exit with 0, got $EXIT_CODE"
+try nvm_remote_version stable
+[ "_$CAPTURED_STDOUT" = "_$(nvm_ls_remote stable)" ] \
+  || die "nvm_remote_version stable did not return contents of nvm_ls_remote stable; got $CAPTURED_STDOUT"
+[ "_$CAPTURED_EXIT_CODE" = "_0" ] || die "nvm_remote_version stable did not exit with 0, got $CAPTURED_EXIT_CODE"
 
-OUTPUT="$(nvm_remote_version unstable)"
-EXIT_CODE="$(nvm_remote_version unstable >/dev/null 2>&1 ; echo $?)"
-[ "_$OUTPUT" = "_$(nvm_ls_remote unstable)" ] \
-  || die "nvm_remote_version unstable did not return contents of nvm_ls_remote unstable; got $OUTPUT"
-[ "_$EXIT_CODE" = "_0" ] || die "nvm_remote_version unstable did not exit with 0, got $EXIT_CODE"
+try nvm_remote_version unstable
+[ "_$CAPTURED_STDOUT" = "_$(nvm_ls_remote unstable)" ] \
+  || die "nvm_remote_version unstable did not return contents of nvm_ls_remote unstable; got $CAPTURED_STDOUT"
+[ "_$CAPTURED_EXIT_CODE" = "_0" ] || die "nvm_remote_version unstable did not exit with 0, got $CAPTURED_EXIT_CODE"
 
-OUTPUT="$(nvm_remote_version node)"
-EXIT_CODE="$(nvm_remote_version node >/dev/null 2>&1 ; echo $?)"
-[ "_$OUTPUT" = "_$(nvm_ls_remote node)" ] \
-  || die "nvm_remote_version node did not return contents of nvm_ls_remote node; got $OUTPUT"
-[ "_$EXIT_CODE" = "_0" ] || die "nvm_remote_version node did not exit with 0, got $EXIT_CODE"
+try nvm_remote_version node
+[ "_$CAPTURED_STDOUT" = "_$(nvm_ls_remote node)" ] \
+  || die "nvm_remote_version node did not return contents of nvm_ls_remote node; got $CAPTURED_STDOUT"
+[ "_$CAPTURED_EXIT_CODE" = "_0" ] || die "nvm_remote_version node did not exit with 0, got $CAPTURED_EXIT_CODE"
 
 # Test LTS name rejection (Issue #3474)
 # When nvm_remote_versions returns a line with LTS name in description,
@@ -83,17 +77,15 @@ EXIT_CODE="$(nvm_remote_version node >/dev/null 2>&1 ; echo $?)"
 nvm_remote_versions() {
     echo "v4.9.1 Argon *"
 }
-OUTPUT="$(nvm_remote_version Argon)"
-EXIT_CODE="$(nvm_remote_version Argon >/dev/null 2>&1 ; echo $?)"
-[ "_$OUTPUT" = "_N/A" ] || die "nvm_remote_version Argon should return N/A (LTS name not in version), got $OUTPUT"
-[ "_$EXIT_CODE" = "_3" ] || die "nvm_remote_version Argon should exit with code 3, got $EXIT_CODE"
+try nvm_remote_version Argon
+[ "_$CAPTURED_STDOUT" = "_N/A" ] || die "nvm_remote_version Argon should return N/A (LTS name not in version), got $CAPTURED_STDOUT"
+[ "_$CAPTURED_EXIT_CODE" = "_3" ] || die "nvm_remote_version Argon should exit with code 3, got $CAPTURED_EXIT_CODE"
 
 nvm_remote_versions() {
   echo "v4.9.1"
 }
-OUTPUT="$(nvm_remote_version 4)"
-EXIT_CODE="$(nvm_remote_version 4 >/dev/null 2>&1 ; echo $?)"
-[ "_$OUTPUT" = "_v4.9.1" ] || die "nvm_remote_version 4 should return v4.9.1, got $OUTPUT"
-[ "_$EXIT_CODE" = "_0" ] || die "nvm_remote_version 4 should exit with code 0, got $EXIT_CODE"
+try nvm_remote_version 4
+[ "_$CAPTURED_STDOUT" = "_v4.9.1" ] || die "nvm_remote_version 4 should return v4.9.1, got $CAPTURED_STDOUT"
+[ "_$CAPTURED_EXIT_CODE" = "_0" ] || die "nvm_remote_version 4 should exit with code 0, got $CAPTURED_EXIT_CODE"
 
 cleanup

--- a/test/fast/Unit tests/nvm_remote_versions
+++ b/test/fast/Unit tests/nvm_remote_versions
@@ -9,33 +9,31 @@ cleanup() {
 : nvm.sh
 \. ../../../nvm.sh
 
-OUTPUT="$(nvm_remote_versions stable 2>&1)"
-EXPECTED_OUTPUT="Implicit aliases are not supported in nvm_remote_versions."
-EXIT_CODE="$(nvm_remote_versions stable >/dev/null 2>&1; echo $?)"
-[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "implicit alias 'stable' did not error out with correct message, got $OUTPUT"
-[ "_$EXIT_CODE" = "_1" ] || die "implicit alias 'stable' did not exit with code 1, got $EXIT_CODE"
+\. ../../common.sh
 
-OUTPUT="$(nvm_remote_versions unstable 2>&1)"
+try_err nvm_remote_versions stable
 EXPECTED_OUTPUT="Implicit aliases are not supported in nvm_remote_versions."
-EXIT_CODE="$(nvm_remote_versions unstable >/dev/null 2>&1; echo $?)"
-[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die "implicit alias 'unstable' did not error out with correct message, got $OUTPUT"
-[ "_$EXIT_CODE" = "_1" ] || die "implicit alias 'unstable' did not exit with code 1, got $EXIT_CODE"
+[ "_$CAPTURED_STDERR" = "_$EXPECTED_OUTPUT" ] || die "implicit alias 'stable' did not error out with correct message, got $CAPTURED_STDERR"
+[ "_$CAPTURED_EXIT_CODE" = "_1" ] || die "implicit alias 'stable' did not exit with code 1, got $CAPTURED_EXIT_CODE"
+
+try_err nvm_remote_versions unstable
+EXPECTED_OUTPUT="Implicit aliases are not supported in nvm_remote_versions."
+[ "_$CAPTURED_STDERR" = "_$EXPECTED_OUTPUT" ] || die "implicit alias 'unstable' did not error out with correct message, got $CAPTURED_STDERR"
+[ "_$CAPTURED_EXIT_CODE" = "_1" ] || die "implicit alias 'unstable' did not exit with code 1, got $CAPTURED_EXIT_CODE"
 
 nvm_ls_remote() {
   echo "N/A"
 }
-OUTPUT="$(nvm_remote_versions foo)"
-EXIT_CODE="$(nvm_remote_versions foo >/dev/null 2>&1 ; echo $?)"
-[ "_$OUTPUT" = "_N/A" ] || die "nonexistent version did not report N/A"
-[ "_$EXIT_CODE" = "_3" ] || die "nonexistent version did not exit with code 3, got $EXIT_CODE"
+try nvm_remote_versions foo
+[ "_$CAPTURED_STDOUT" = "_N/A" ] || die "nonexistent version did not report N/A"
+[ "_$CAPTURED_EXIT_CODE" = "_3" ] || die "nonexistent version did not exit with code 3, got $CAPTURED_EXIT_CODE"
 
 nvm_ls_remote_iojs() {
   echo "N/A"
 }
-OUTPUT="$(nvm_remote_versions iojs-foo)"
-EXIT_CODE="$(nvm_remote_versions iojs-foo >/dev/null 2>&1 ; echo $?)"
-[ "_$OUTPUT" = "_N/A" ] || die "nonexistent version did not report N/A"
-[ "_$EXIT_CODE" = "_3" ] || die "nonexistent version did not exit with code 3, got $EXIT_CODE"
+try nvm_remote_versions iojs-foo
+[ "_$CAPTURED_STDOUT" = "_N/A" ] || die "nonexistent version did not report N/A"
+[ "_$CAPTURED_EXIT_CODE" = "_3" ] || die "nonexistent version did not exit with code 3, got $CAPTURED_EXIT_CODE"
 
 
 nvm_ls_remote() {
@@ -49,30 +47,26 @@ nvm_ls_remote_iojs() {
   echo "iojs pattern received: _$1_"
 }
 
-OUTPUT="$(nvm_remote_versions foo)"
-EXIT_CODE="$(nvm_remote_versions foo >/dev/null 2>&1 ; echo $?)"
-[ "_$OUTPUT" = "_$(nvm_ls_remote foo)
+try nvm_remote_versions foo
+[ "_$CAPTURED_STDOUT" = "_$(nvm_ls_remote foo)
 $(nvm_ls_remote_iojs foo)" ] \
-  || die "nvm_remote_versions foo did not return contents of nvm_ls_remote foo combined with nvm_ls_remote_iojs foo; got $OUTPUT"
-[ "_$EXIT_CODE" = "_0" ] || die "nvm_remote_versions foo did not exit with 0, got $EXIT_CODE"
+  || die "nvm_remote_versions foo did not return contents of nvm_ls_remote foo combined with nvm_ls_remote_iojs foo; got $CAPTURED_STDOUT"
+[ "_$CAPTURED_EXIT_CODE" = "_0" ] || die "nvm_remote_versions foo did not exit with 0, got $CAPTURED_EXIT_CODE"
 
-OUTPUT="$(nvm_remote_versions node)"
-EXIT_CODE="$(nvm_remote_versions node >/dev/null 2>&1 ; echo $?)"
-[ "_$OUTPUT" = "_$(nvm_ls_remote)" ] \
-  || die "nvm_remote_versions node did not return contents of nvm_ls_remote; got $OUTPUT"
-[ "_$EXIT_CODE" = "_0" ] || die "nvm_remote_versions node did not exit with 0, got $EXIT_CODE"
+try nvm_remote_versions node
+[ "_$CAPTURED_STDOUT" = "_$(nvm_ls_remote)" ] \
+  || die "nvm_remote_versions node did not return contents of nvm_ls_remote; got $CAPTURED_STDOUT"
+[ "_$CAPTURED_EXIT_CODE" = "_0" ] || die "nvm_remote_versions node did not exit with 0, got $CAPTURED_EXIT_CODE"
 
-OUTPUT="$(nvm_remote_versions iojs-foo)"
-EXIT_CODE="$(nvm_remote_versions iojs-foo >/dev/null 2>&1 ; echo $?)"
-[ "_$OUTPUT" = "_$(nvm_ls_remote iojs-foo)
+try nvm_remote_versions iojs-foo
+[ "_$CAPTURED_STDOUT" = "_$(nvm_ls_remote iojs-foo)
 $(nvm_ls_remote_iojs iojs-foo)" ] \
-  || die "nvm_remote_versions iojs-foo did not return contents of nvm_ls_remote iojs-foo combined with nvm_ls_remote_iojs iojs-foo; got $OUTPUT"
-[ "_$EXIT_CODE" = "_0" ] || die "nvm_remote_versions iojs-foo did not exit with 0, got $EXIT_CODE"
+  || die "nvm_remote_versions iojs-foo did not return contents of nvm_ls_remote iojs-foo combined with nvm_ls_remote_iojs iojs-foo; got $CAPTURED_STDOUT"
+[ "_$CAPTURED_EXIT_CODE" = "_0" ] || die "nvm_remote_versions iojs-foo did not exit with 0, got $CAPTURED_EXIT_CODE"
 
-OUTPUT="$(nvm_remote_versions iojs)"
-EXIT_CODE="$(nvm_remote_versions iojs >/dev/null 2>&1 ; echo $?)"
-[ "_$OUTPUT" = "_$(nvm_ls_remote_iojs)" ] \
-  || die "nvm_remote_versions iojs did not return contents of nvm_ls_remote_iojs; got $OUTPUT"
-[ "_$EXIT_CODE" = "_0" ] || die "nvm_remote_versions iojs did not exit with 0, got $EXIT_CODE"
+try nvm_remote_versions iojs
+[ "_$CAPTURED_STDOUT" = "_$(nvm_ls_remote_iojs)" ] \
+  || die "nvm_remote_versions iojs did not return contents of nvm_ls_remote_iojs; got $CAPTURED_STDOUT"
+[ "_$CAPTURED_EXIT_CODE" = "_0" ] || die "nvm_remote_versions iojs did not exit with 0, got $CAPTURED_EXIT_CODE"
 
 cleanup

--- a/test/fast/Unit tests/nvm_validate_implicit_alias
+++ b/test/fast/Unit tests/nvm_validate_implicit_alias
@@ -5,15 +5,17 @@ die () { echo "$@" ; exit 1; }
 : nvm.sh
 \. ../../../nvm.sh
 
+\. ../../common.sh
+
 EXPECTED_MSG="Only implicit aliases 'stable', 'unstable', 'iojs', and 'node' are supported."
 [ "_$(nvm_validate_implicit_alias 2>&1)" = "_$EXPECTED_MSG" ] \
   || die "nvm_validate_implicit_alias did not require stable|unstable|iojs|node"
 [ "_$(nvm_validate_implicit_alias foo 2>&1)" = "_$EXPECTED_MSG" ] \
   || die "nvm_validate_implicit_alias did not require stable|unstable|iojs|node"
 
-EXIT_CODE="$(nvm_validate_implicit_alias >/dev/null 2>&1 ; echo $?)"
-[ "_$EXIT_CODE" = "_1" ] \
-  || die "nvm_validate_implicit_alias without stable|unstable|iojs|node had wrong exit code: expected 1, got $EXIT_CODE"
+try_err nvm_validate_implicit_alias
+[ "_$CAPTURED_EXIT_CODE" = "_1" ] \
+  || die "nvm_validate_implicit_alias without stable|unstable|iojs|node had wrong exit code: expected 1, got $CAPTURED_EXIT_CODE"
 
 nvm_validate_implicit_alias stable || die "nvm_validate_implicit_alias stable did not exit 0"
 nvm_validate_implicit_alias unstable || die "nvm_validate_implicit_alias unstable did not exit 0"

--- a/test/fast/Unit tests/nvm_version
+++ b/test/fast/Unit tests/nvm_version
@@ -8,22 +8,22 @@ cleanup () {
 : nvm.sh
 \. ../../../nvm.sh
 
+\. ../../common.sh
+
 nvm_ls_current() {
   echo "CURRENT!"
   return 7
 }
 
-OUTPUT="$(nvm_version current)"
+try nvm_version current
 EXPECTED_OUTPUT="CURRENT!"
-EXIT_CODE="$(nvm_version current 2>&1 >/dev/null ; echo $?)"
-[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die '"nvm_version current" did not return nvm_ls_current output'
-[ "_$EXIT_CODE" = "_7" ] || die '"nvm_version current" did not return nvm_ls_current exit code'
+[ "_$CAPTURED_STDOUT" = "_$EXPECTED_OUTPUT" ] || die '"nvm_version current" did not return nvm_ls_current output'
+[ "_$CAPTURED_EXIT_CODE" = "_7" ] || die '"nvm_version current" did not return nvm_ls_current exit code'
 
-OUTPUT="$(nvm_version)"
+try nvm_version
 EXPECTED_OUTPUT="CURRENT!"
-EXIT_CODE="$(nvm_version 2>&1 >/dev/null ; echo $?)"
-[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die '"nvm_version" did not return nvm_ls_current output'
-[ "_$EXIT_CODE" = "_7" ] || die '"nvm_version" did not return nvm_ls_current exit code'
+[ "_$CAPTURED_STDOUT" = "_$EXPECTED_OUTPUT" ] || die '"nvm_version" did not return nvm_ls_current output'
+[ "_$CAPTURED_EXIT_CODE" = "_7" ] || die '"nvm_version" did not return nvm_ls_current exit code'
 
 nvm_ls() {
   echo "line 1"
@@ -38,15 +38,13 @@ nvm_ls() { echo "system v20.0.0"; }
 [ "_$(nvm_version system)" = "_system" ] || die '"nvm_version system" did not return "system" when "nvm_ls" returns extra columns'
 
 nvm_ls() { echo "N/A"; }
-OUTPUT="$(nvm_version foo)"
+try nvm_version foo
 EXPECTED_OUTPUT="N/A"
-EXIT_CODE="$(nvm_version foo 2>&1 >/dev/null ; echo $?)"
-[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die '"nvm_version" did not return N/A when nvm_ls returns N/A'
-[ "_$EXIT_CODE" = "_3" ] || die '"nvm_version" returning N/A did not exit code with code 3'
+[ "_$CAPTURED_STDOUT" = "_$EXPECTED_OUTPUT" ] || die '"nvm_version" did not return N/A when nvm_ls returns N/A'
+[ "_$CAPTURED_EXIT_CODE" = "_3" ] || die '"nvm_version" returning N/A did not exit code with code 3'
 
 nvm_ls() { echo; }
-OUTPUT="$(nvm_version foo)"
+try nvm_version foo
 EXPECTED_OUTPUT="N/A"
-EXIT_CODE="$(nvm_version foo 2>&1 >/dev/null ; echo $?)"
-[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] || die '"nvm_version" did not return N/A when nvm_ls returns nothing'
-[ "_$EXIT_CODE" = "_3" ] || die '"nvm_version" returning N/A did not exit code with code 3'
+[ "_$CAPTURED_STDOUT" = "_$EXPECTED_OUTPUT" ] || die '"nvm_version" did not return N/A when nvm_ls returns nothing'
+[ "_$CAPTURED_EXIT_CODE" = "_3" ] || die '"nvm_version" returning N/A did not exit code with code 3'

--- a/test/slow/nvm use/Running 'nvm use' calls 'nvm_die_on_prefix'
+++ b/test/slow/nvm use/Running 'nvm use' calls 'nvm_die_on_prefix'
@@ -4,6 +4,8 @@ die () { echo "$@" ; exit 1; }
 
 \. ../../../nvm.sh
 
+\. ../../common.sh
+
 nvm deactivate >/dev/null 2>&1 || die 'deactivate failed'
 
 nvm_die_on_prefix() {
@@ -11,12 +13,12 @@ nvm_die_on_prefix() {
   return 3
 }
 
-OUTPUT="$(nvm use --silent node)"
+try nvm use --silent node
 EXPECTED_OUTPUT=""
-[ "_$OUTPUT" = "_$EXPECTED_OUTPUT" ] \
-  || die "'nvm use --silent node' did not call through to 'nvm_die_on_prefix' and give output '$EXPECTED_OUTPUT'; got '$OUTPUT'"
+[ "_$CAPTURED_STDOUT" = "_$EXPECTED_OUTPUT" ] \
+  || die "'nvm use --silent node' did not call through to 'nvm_die_on_prefix' and give output '$EXPECTED_OUTPUT'; got '$CAPTURED_STDOUT'"
 
-EXIT_CODE="$(nvm use --silent node >/dev/null 2>&1; echo $?)"
+try_err nvm use --silent node
 EXPECTED_CODE="11"
-[ "_$EXIT_CODE" = "_$EXPECTED_CODE" ] \
-  || die "'nvm use --silent node' when 'nvm_die_on_prefix' fails did not return '$EXPECTED_CODE'; got '$EXIT_CODE'"
+[ "_$CAPTURED_EXIT_CODE" = "_$EXPECTED_CODE" ] \
+  || die "'nvm use --silent node' when 'nvm_die_on_prefix' fails did not return '$EXPECTED_CODE'; got '$CAPTURED_EXIT_CODE'"

--- a/test/slow/nvm_get_latest/nvm_get_latest
+++ b/test/slow/nvm_get_latest/nvm_get_latest
@@ -90,12 +90,13 @@ wget() {
   fi
 }
 
-OUTPUT="$(nvm_get_latest)"
-EXIT_CODE="$(nvm_get_latest >/dev/null 2>&1 ; echo $?)"
-[ "_$OUTPUT" = "_$EXPECTED_VERSION" ] \
-  || die "success path did not return version '$EXPECTED_VERSION', got '$OUTPUT'"
-[ "_$EXIT_CODE" = "_0" ] \
-  || die "success path did not exit with code 0, got $EXIT_CODE"
+\. ../../common.sh
+
+try nvm_get_latest
+[ "_$CAPTURED_STDOUT" = "_$EXPECTED_VERSION" ] \
+  || die "success path did not return version '$EXPECTED_VERSION', got '$CAPTURED_STDOUT'"
+[ "_$CAPTURED_EXIT_CODE" = "_0" ] \
+  || die "success path did not exit with code 0, got $CAPTURED_EXIT_CODE"
 
 
 cleanup

--- a/test/slow/nvm_get_latest/nvm_get_latest failed redirect
+++ b/test/slow/nvm_get_latest/nvm_get_latest failed redirect
@@ -8,6 +8,8 @@ cleanup() {
 
 \. ../../../nvm.sh
 
+\. ../../common.sh
+
 curl() {
   return 1
 }
@@ -15,11 +17,10 @@ wget() {
   return 1
 }
 
-OUTPUT="$(nvm_get_latest 2>&1)"
-EXIT_CODE="$(nvm_get_latest >/dev/null 2>&1 ; echo $?)"
-[ "_$OUTPUT" = "_https://latest.nvm.sh did not redirect to the latest release on GitHub" ] \
-  || die "failed redirect did not report correct error message, got '$OUTPUT'"
-[ "_$EXIT_CODE" = "_2" ] \
-  || die "failed redirect did not exit with code 2, got $EXIT_CODE"
+try_err nvm_get_latest
+[ "_$CAPTURED_STDERR" = "_https://latest.nvm.sh did not redirect to the latest release on GitHub" ] \
+  || die "failed redirect did not report correct error message, got '$CAPTURED_STDERR'"
+[ "_$CAPTURED_EXIT_CODE" = "_2" ] \
+  || die "failed redirect did not exit with code 2, got $CAPTURED_EXIT_CODE"
 
 cleanup


### PR DESCRIPTION
## Summary by Sourcery

Add offline installation support that installs Node versions from local cache only and refactor .nvmrc version resolution to avoid global state side effects.

New Features:
- Introduce an `--offline` flag for `nvm install` to install Node versions using only locally installed versions and cached downloads.
- Add `nvm_ls_cached` and `nvm_offline_version` helpers to resolve versions from the local cache without network access.

Enhancements:
- Update artifact download logic to honor offline mode by reusing cached archives and skipping checksum and network requests.
- Refine .nvmrc handling so `nvm_rc_version` returns the resolved version via a dedicated file descriptor instead of relying on a global variable.
- Improve alias/color handling so color support is computed once and propagated to parallel alias-printing commands.

Documentation:
- Document offline installation usage and behavior in the README, including combining `--offline` with `--lts`.

Tests:
- Add test helpers to capture stdout/stderr and exit codes, and extend unit tests to cover offline install/version resolution and updated .nvmrc behavior.